### PR TITLE
Code Action: case-split

### DIFF
--- a/src/Language/LSP/CodeAction/CaseSplit.idr
+++ b/src/Language/LSP/CodeAction/CaseSplit.idr
@@ -1,0 +1,109 @@
+module Language.LSP.CodeAction.CaseSplit
+
+import Core.Context
+import Core.Core
+import Core.Env
+import Core.Metadata
+import Core.UnifyState
+import Data.List1
+import Data.String
+import Idris.IDEMode.CaseSplit
+import Idris.REPL.Opts
+import Idris.Syntax
+import Idris.Syntax
+import Language.JSON
+import Language.LSP.Message
+import Libraries.Data.List.Extra
+import Libraries.Data.PosMap
+import Server.Configuration
+import Server.Response
+import Server.Utils
+import System.File
+import TTImp.Interactive.CaseSplit
+import TTImp.TTImp
+
+-- fork of updateCase in Idris.IDEMode.CaseSplit.updateCase
+originalLine
+  : {auto c : Ref Ctxt Defs} ->
+    {auto s : Ref Syn SyntaxInfo} ->
+    {auto o : Ref ROpts REPLOpts} ->
+    List ClauseUpdate -> Int -> Int ->
+    Core String
+originalLine splits line col
+    = do opts <- get ROpts
+         case mainfile opts of
+              Nothing => throw (InternalError "No file loaded")
+              Just f =>
+                do Right file <- coreLift $ readFile f
+                       | Left err => throw (FileErr f err)
+                   let thisline = elemAt (forget $ lines file) (integerToNat (cast line))
+                   case thisline of
+                        Nothing => throw (InternalError "File too short!")
+                        Just l => pure l
+  where
+    getValid : ClauseUpdate -> Maybe (List (Name, RawImp))
+    getValid (Valid _ ups) = Just ups
+    getValid _ = Nothing
+
+    getBad : ClauseUpdate -> Maybe RawImp
+    getBad (Impossible lhs) = Just lhs
+    getBad _ = Nothing
+
+export
+caseSplit : Ref LSPConf LSPConfiguration
+         => Ref MD Metadata
+         => Ref Ctxt Defs
+         => Ref UST UState
+         => Ref Syn SyntaxInfo
+         => Ref ROpts REPLOpts
+         => Int .+. String .+. Null -> CodeActionParams -> Core ()
+caseSplit msgId params = do
+  let True = params.range.start.line == params.range.end.line
+      | _ =>
+        sendResponseMessage
+          TextDocumentCodeAction
+          (Failure msgId (MkResponseError InvalidParams "Multiple lines were selected." JNull))
+
+  meta <- get MD
+  let line = params.range.start.line
+  let col = params.range.start.character
+  let Just name = findInTree (line, col) (nameLocMap meta)
+      | Nothing =>
+          sendResponseMessage
+            TextDocumentCodeAction
+            (Failure msgId (MkResponseError InternalError "Can't find name" JNull))
+
+  let find = if col > 0
+                then within (line, col)
+                else onLine line
+
+  OK splits <- getSplits (anyAt find) name
+     | SplitFail err => do
+        sendResponseMessage
+          TextDocumentCodeAction
+          (Failure msgId (MkResponseError InternalError "Can't split: \{show err}" JNull))
+
+  lines <- updateCase splits line col
+  original <- originalLine splits line col
+
+  let docURI = params.textDocument.uri
+  let rng = MkRange (MkPosition line 0)
+                    (MkPosition line (cast (length original)))
+  let edit = MkTextEdit rng (unlines lines)
+  let workspaceEdit = MkWorkspaceEdit
+        { changes           = Just (singleton docURI [edit])
+        , documentChanges   = Nothing
+        , changeAnnotations = Nothing
+        }
+  let caseSplitCodeAction = MkCodeAction
+        { title       = "Case split on \{show name}"
+        , kind        = Just $ Other "case-split"
+        , diagnostics = Just []
+        , isPreferred = Just False
+        , disabled    = Nothing
+        , edit        = Just workspaceEdit
+        , command     = Nothing
+        , data_       = Nothing
+        }
+  let response = Success msgId (Left [Right caseSplitCodeAction])
+  sendResponseMessage TextDocumentCodeAction response

--- a/src/Server/Capabilities.idr
+++ b/src/Server/Capabilities.idr
@@ -30,7 +30,11 @@ serverCapabilities =
                        , referencesProvider               = Just (Left False)
                        , documentHighlightProvider        = Just (Left False)
                        , documentSymbolProvider           = Just (Left False)
-                       , codeActionProvider               = Just (Left False)
+                       , codeActionProvider               = Just (Right
+                                                                 (MkCodeActionOptions
+                                                                    Nothing
+                                                                    (Just [Other "case-split"])
+                                                                    (Just False)))
                        , codeLensProvider                 = Just (MkCodeLensOptions Nothing Nothing)
                        , documentLinkProvider             = Just (MkDocumentLinkOptions Nothing Nothing)
                        , colorProvider                    = Just (Left False)

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -45,16 +45,6 @@ displayTerm defs tm
     = do ptm <- resugar [] !(normaliseHoles defs [] tm)
          pure (prettyTerm ptm)
 
-findInTree : FilePos -> PosMap (NonEmptyFC, Name) -> Maybe Name
-findInTree p m = map snd $ head' $ sortBy (\x, y => cmp (measure x) (measure y)) $ searchPos p m
-  where
-    cmp : FileRange -> FileRange -> Ordering
-    cmp ((sr1, sc1), (er1, ec1)) ((sr2, sc2), (er2, ec2)) =
-      compare (er1 - sr1, ec1 - sc1) (er2 - sr2, ec2 - sr2)
-
-anyAt : (a -> Bool) -> a -> b -> Bool
-anyAt p loc _ = p loc
-
 ||| Guard for messages that requires a successful initialization before being allowed.
 whenInitialized : Ref LSPConf LSPConfiguration => (InitializeParams -> Core ()) -> Core ()
 whenInitialized k =

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -17,6 +17,7 @@ import Idris.REPL.Opts
 import Idris.Resugar
 import Idris.Syntax
 import Idris.IDEMode.Holes
+import Language.LSP.CodeAction.CaseSplit
 import Language.JSON
 import Language.LSP.Message
 import Libraries.Data.PosMap
@@ -150,6 +151,10 @@ processMessage TextDocumentHover msg@(MkRequestMessage id TextDocumentHover para
       (Nothing, Nothing) => pure ""
     let response = Success (getResponseId msg) (Left $ MkHover (Right $ Right $ MkMarkupContent PlainText line) Nothing)
     sendResponseMessage TextDocumentHover response
+
+processMessage TextDocumentCodeAction msg@(MkRequestMessage id TextDocumentCodeAction params) =
+  whenNotShutdown $ whenInitialized $ \_ => caseSplit (getResponseId msg) params
+
 processMessage {type = Request} method msg =
   whenNotShutdown $ whenInitialized $ \conf => do
     logString Warning $ "received a not supported" ++ show (toJSON method) ++ " request"

--- a/src/Server/Utils.idr
+++ b/src/Server/Utils.idr
@@ -4,10 +4,13 @@
 module Server.Utils
 
 import Core.Core
+import Core.FC
+import Core.Name
 import Data.Bits
 import Data.List
 import Data.Strings
 import Language.JSON
+import Libraries.Data.PosMap
 import System.File
 
 ||| Gets a specific component of a reference, using the supplied projection.
@@ -100,3 +103,15 @@ stringify (JObject xs) = "{" ++ stringifyProps xs ++ "}"
                             ++ if isNil xs
                                   then ""
                                   else "," ++ stringifyProps xs
+
+export
+findInTree : FilePos -> PosMap (NonEmptyFC, Name) -> Maybe Name
+findInTree p m = map snd $ head' $ sortBy (\x, y => cmp (measure x) (measure y)) $ searchPos p m
+  where
+    cmp : FileRange -> FileRange -> Ordering
+    cmp ((sr1, sc1), (er1, ec1)) ((sr2, sc2), (er2, ec2)) =
+      compare (er1 - sr1, ec1 - sc1) (er2 - sr2, ec2 - sr2)
+
+export
+anyAt : (a -> Bool) -> a -> b -> Bool
+anyAt p loc _ = p loc


### PR DESCRIPTION
First version of the case-split code action.

This is not the most efficient way. The command part of the response needs to be looked into. The drawback of this approach that when the client ask for the code action, the change is prematurely computed. This can be a problem with the clients looking for code actions at every code point. Another improvement which is needed to be done is somehow contextualize this command to be able to invoke only on function parameter at function definition.

But at least we have something, and the rest of the Idris2LSP team can look into adding further code actions.