### PR TITLE
Option for long actions timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Server options that can be set via the `initializationOptions` object in the ini
 |Option key|Type|Description|
 |----------|----|-----------|
 |`logFile`|`string`|Absolute location of the log file for the server (default: stderr)|
+|`longActionTimeout`|`number`|Timeout in ms for long actions, e.g. expression search (default: 5000)|

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -13,6 +13,7 @@ import Language.LSP.Message.Location
 import Language.LSP.Message.URI
 import Libraries.Data.PosMap
 import System.File
+import System.Clock
 
 ||| Label for the configuration reference.
 public export
@@ -44,20 +45,24 @@ record LSPConfiguration where
   cachedActions : PosMap (Range, IdrisAction, List CodeAction)
   ||| Cached hovers
   cachedHovers : PosMap (Range, Hover)
+  ||| Timeout in ms for long operations (currently stops multiple commands, e.g. ExprSearch)
+  ||| TODO: extend it to any operation and report the timeout, making it overridable
+  longActionTimeout : Clock Duration
 
 ||| Server default configuration. Uses standard input and standard output for input/output.
 export
 defaultConfig : LSPConfiguration
 defaultConfig =
   MkLSPConfiguration
-    { inputHandle   = stdin
-    , outputHandle  = stdout
-    , logHandle     = stderr
-    , initialized   = Nothing
-    , isShutdown    = False
-    , openFile      = Nothing
-    , searchLimit   = 5
-    , quickfixes    = []
-    , cachedActions = empty
-    , cachedHovers  = empty
+    { inputHandle       = stdin
+    , outputHandle      = stdout
+    , logHandle         = stderr
+    , initialized       = Nothing
+    , isShutdown        = False
+    , openFile          = Nothing
+    , searchLimit       = 5
+    , quickfixes        = []
+    , cachedActions     = empty
+    , cachedHovers      = empty
+    , longActionTimeout = makeDuration 5 0
     }


### PR DESCRIPTION
Currently timeouts only multiple actions, i.e. ExprSearch/GeneratedDef. Future work would be enforcing this timeout on each action, but requires changes in the compiler.