### PR TITLE
Add missing space

### DIFF
--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -359,7 +359,7 @@ perror (InRHS fc n err)
     = pure $ hsep [ errorDesc (reflow "While processing right hand side of" <++> code (pretty !(prettyName n))) <+> dot
                   , !(perror err)
                   ]
-perror (MaybeMisspelling err ns) = pure $ !(perror err) <+> case ns of
+perror (MaybeMisspelling err ns) = pure $ !(perror err) <++> case ns of
   (n ::: []) => reflow "Did you mean:" <++> pretty n <+> "?"
   _ => let (xs, x) = unsnoc ns in
        reflow "Did you mean any of:"


### PR DESCRIPTION
<img width="576" alt="Screen Shot 2021-05-08 at 9 43 25 PM" src="https://user-images.githubusercontent.com/16529951/117561649-2fc84300-b05e-11eb-9b6e-68c8dd5f76d1.png">

Add a missing space. A new line would also work. Or maybe it should be changed to a quick fix.