### PR TITLE
Make case-split work on emacs lsp-idris2.

### DIFF
--- a/src/Language/LSP/CodeAction/CaseSplit.idr
+++ b/src/Language/LSP/CodeAction/CaseSplit.idr
@@ -71,7 +71,7 @@ caseSplit params = do
         }
   let action = MkCodeAction
         { title       = "Case split on ?\{show name}"
-        , kind        = Just $ Other "case-split"
+        , kind        = Just $ Other "refactor.rewrite.auto"
         , diagnostics = Just []
         , isPreferred = Just False
         , disabled    = Nothing

--- a/src/Language/LSP/CodeAction/ExprSearch.idr
+++ b/src/Language/LSP/CodeAction/ExprSearch.idr
@@ -87,7 +87,7 @@ exprSearch params = do
   let True = params.range.start.line == params.range.end.line
     | _ => pure []
 
-  [] <- searchCache params.range CaseSplit
+  [] <- searchCache params.range ExprSearch
     | actions => do logString Debug "exprSearch: found cached action"
                     pure actions
 

--- a/src/Language/LSP/CodeAction/MakeWith.idr
+++ b/src/Language/LSP/CodeAction/MakeWith.idr
@@ -52,7 +52,7 @@ makeWith params = do
     | _ => do logString Debug "makeWith: start and end line were different"
               pure Nothing
 
-  [] <- searchCache params.range CaseSplit
+  [] <- searchCache params.range MakeWith
     | action :: _ => do logString Debug "makeWith: found cached action"
                         pure (Just action)
 


### PR DESCRIPTION
I try to play around emacs's LSP client and found some issue for case-split. 
Idris2-lsp's current implementation has two issues for emacs LSP client.
1. emacs LSP client cannot handle case-split kind. I changed the kind to refactor.rewrite.auto.
2. After I changed the above, I got three same recommendations. It seems it is because argument to searchCache mismatch.
This PR changed the above two.
In case of 1, case-split instead of refactor.rewrite.auto is what you expect, let me know about it, I'll consider to implement it on emacs lsp-idris2.