### PR TITLE
Always send absolute paths to the client in go-to-def

### DIFF
--- a/src/Language/LSP/Definition.idr
+++ b/src/Language/LSP/Definition.idr
@@ -27,24 +27,28 @@ mkLocation origin (sline, scol) (eline, ecol) = do
     | _ => do
        logString Debug "gotoDefinition: Origin doesn't have an Idris file attached to it \{show origin}"
        pure Nothing
+  let wdir = defs.options.dirs.working_dir
   let pkg_dirs = filter (/= ".") defs.options.dirs.extra_dirs
   let exts = map show listOfExtensions
-  Just fname <- catch
-      (Just <$> nsToSource replFC modIdent) -- Try local source first
-      -- if not found, try looking for the file amonst the loaded packages.
+  Just fname_abs <- catch
+      (Just . (wdir </>) <$> nsToSource replFC modIdent) -- Try local source first
+      -- if not found, try looking for the file amongst the loaded packages.
       (const $ firstAvailable $ do
         pkg_dir <- pkg_dirs
+        -- Assume that if the package dir is relative, then it must be relative to
+        -- the working directory of the running Idris2 instance.
+        let pkg_dir_abs = ifThenElse (isRelative pkg_dir) (wdir </> pkg_dir) pkg_dir
         ext <- exts
-        pure (pkg_dir </> ModuleIdent.toPath modIdent <.> ext))
+        pure (pkg_dir_abs </> ModuleIdent.toPath modIdent <.> ext))
     | _ => do
       logString Debug "gotoDefinition: Can't find file for module \{show modIdent}"
       pure Nothing
 
-  let fname = "file://" ++ fname
+  let fname_abs_uri = "file://" ++ fname_abs
 
-  let Right (uri, _) = parse uriReferenceParser fname
+  let Right (uri, _) = parse uriReferenceParser fname_abs_uri
       | Left err => do
-          logString Debug "gotoDefinition: URI parse error: \{err} \{show (fname, sline, scol)}"
+          logString Debug "gotoDefinition: URI parse error: \{err} \{show (fname_abs_uri, sline, scol)}"
           pure Nothing
 
   pure $ Just $ MkLocation uri (MkRange (MkPosition sline scol) (MkPosition eline ecol))


### PR DESCRIPTION
Should make the file location data, sent back to the client by the go-to-def processor, conform with the LSP standard better.