### PR TITLE
Check environment for package locations

### DIFF
--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -149,9 +149,23 @@ main = do
               the (Core ()) $ case bpath of
                    Just path => do traverseList1_ addExtraDir (map trim (split (==pathSeparator) path))
                    Nothing => pure ()
+              bdata <- coreLift $ idrisGetEnv "IDRIS2_DATA"
+              the (Core ()) $ case bdata of
+                   Just path => do traverseList1_ addDataDir (map trim (split (==pathSeparator) path))
+                   Nothing => pure ()
+              blibs <- coreLift $ idrisGetEnv "IDRIS2_LIBS"
+              the (Core ()) $ case blibs of
+                   Just path => do traverseList1_ addLibDir (map trim (split (==pathSeparator) path))
+                   Nothing => pure ()
               pdirs <- coreLift $ idrisGetEnv "IDRIS2_PACKAGE_PATH"
               the (Core ()) $ case pdirs of
                    Just path => do traverseList1_ addPackageDir (map trim (split (==pathSeparator) path))
+                   Nothing => pure ()
+              cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
+              the (Core ()) $ case cg of
+                   Just e => case getCG (options defs) e of
+                                  Just cg => setCG cg
+                                  Nothing => throw (InternalError ("Unknown code generator " ++ show e))
                    Nothing => pure ()
               addPkgDir "prelude" anyBounds
               addPkgDir "base" anyBounds

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -12,6 +12,7 @@ import Compiler.Common
 import Data.List1
 import Data.Strings
 import Idris.CommandLine
+import Idris.Env
 import Idris.REPL.Opts
 import Idris.REPL.Common
 import Idris.Package.Types
@@ -140,7 +141,14 @@ main = do
               c <- newRef Ctxt defs
               s <- newRef Syn initSyntax
               addPrimitives
-              setPrefix yprefix
+              bprefix <- coreLift $ idrisGetEnv "IDRIS2_PREFIX"
+              the (Core ()) $ case bprefix of
+                   Just p => setPrefix p
+                   Nothing => setPrefix yprefix
+              pdirs <- coreLift $ idrisGetEnv "IDRIS2_PACKAGE_PATH"
+              the (Core ()) $ case pdirs of
+                   Just path => do traverseList1_ addPackageDir (map trim (split (==pathSeparator) path))
+                   Nothing => pure ()
               addPkgDir "prelude" anyBounds
               addPkgDir "base" anyBounds
               addDataDir (prefix_dir (dirs (options defs)) </> ("idris2-" ++ showVersion False version) </> "support")

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -145,6 +145,10 @@ main = do
               the (Core ()) $ case bprefix of
                    Just p => setPrefix p
                    Nothing => setPrefix yprefix
+              bpath <- coreLift $ idrisGetEnv "IDRIS2_PATH"
+              the (Core ()) $ case bpath of
+                   Just path => do traverseList1_ addExtraDir (map trim (split (==pathSeparator) path))
+                   Nothing => pure ()
               pdirs <- coreLift $ idrisGetEnv "IDRIS2_PACKAGE_PATH"
               the (Core ()) $ case pdirs of
                    Just path => do traverseList1_ addPackageDir (map trim (split (==pathSeparator) path))


### PR DESCRIPTION
Idris2 can use environment variables to help locate packages. As far as I can tell, the lsp relies purely on `yprefix` -- that is, the value of PREFIX when idris2 was built. I copied these lines directly from `Idris/Driver.idr`. 

Included environment variables:
* IDRIS2_PREFIX
* IDRIS2_PACKAGE_PATHS
* IDRIS2_PATH

There are a few other environment variables in the same spot in the Idris source that I skipped, because as far as I can tell, they are used primarily for code generation. (I haven't looked much into the lsp yet. Do we need these too?)
Those are:
* IDRIS2_DATA ("data files", i.e. `support/chez/support.ss`, `support/docs/styles.css`)
* IDRIS2_LIBS (code generation libraries)
* IDRIS2_CG (string, i.e. "chez")