### PR TITLE
Use the newly introduced Timeout error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
+include config.mk
+
+# Idris 2 executable we're building
+NAME = idris2-lsp
+TARGETDIR = ${CURDIR}/build/exec
+TARGET = ${TARGETDIR}/${NAME}
+
 .PHONY: build
+
 build:
 	idris2 --build lsp.ipkg
 
 clean:
 	idris2 --clean lsp.ipkg
-	rm -r build
+	$(RM) -r build
 
 repl:
 	rlwrap idris2 --repl lsp.ipkg
@@ -17,3 +25,12 @@ test-only:
 	${MAKE} -C tests only=$(only)
 
 test: build testbin test-only
+
+install: build
+	mkdir -p ${PREFIX}/bin/
+	install ${TARGET} ${PREFIX}/bin
+ifeq ($(OS), windows)
+	-install ${TARGET}.cmd ${PREFIX}/bin
+endif
+	mkdir -p ${PREFIX}/bin/${NAME}_app
+	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Server options that can be set via the `initializationOptions` object in the ini
 |----------|----|-----------|
 |`logFile`|`string`|Absolute location of the log file for the server (default: stderr)|
 |`longActionTimeout`|`number`|Timeout in ms for long actions, e.g. expression search (default: 5000)|
+|`maxCodeActionResults`|`number`|Maximum number of multiple code actions for a single command, e.g. expression search (default: 5)|
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ To compile `idris2-lsp` you need `Idris2-0.4.0` (available [here](https://github
 
 **NOTE: The version of the Idris2 compiler available as submodule is the only tested version. The main branch will be synced with the latest Idris2 release. Visit the nightly branch for more cutting-edge support, we will try to keep up with the Idris2 master branch.**
 
+## Install
+Run `make install` to install the server, by default it will be placed in the same default directory of the Idris2 compiler, i.e. `~/.idris2/bin`.
+
 ## Go to commands and package dependencies
 The server provides support for some go to commands, e.g. go to definition, however to reach modules declared in other packages you must install packages with `idris2 --install-with-src` instead of `idris2 --install`. To access the standard library run `make install-with-src-libs` after building the compiler and `make install-with-src-api` if you also want to access to the `idris2api` package.
 

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,50 @@
+##### Options which a user might set before building go here #####
+
+# Where to install idris2 binaries and libraries (must be an absolute path)
+PREFIX ?= $(HOME)/.idris2
+
+# For Windows targets. Set to 1 to support Windows 7.
+OLD_WIN ?= 0
+
+##################################################################
+
+RANLIB ?= ranlib
+AR ?= ar
+
+CFLAGS := -Wall $(CFLAGS)
+LDFLAGS := $(LDFLAGS)
+
+MACHINE := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring cygwin, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring mingw, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring windows, $(MACHINE)))
+	OS := windows
+	SHLIB_SUFFIX := .dll
+else ifneq (,$(findstring darwin, $(MACHINE)))
+	OS := darwin
+	SHLIB_SUFFIX := .dylib
+	CFLAGS += -fPIC
+else ifneq (, $(findstring bsd, $(MACHINE)))
+	OS := bsd
+	SHLIB_SUFFIX := .so
+	CFLAGS += -fPIC
+else
+	OS := linux
+	SHLIB_SUFFIX := .so
+	CFLAGS += -fPIC
+endif
+export OS
+
+ifeq ($(OS),bsd)
+	MAKE := gmake
+else
+	MAKE := make
+endif
+export MAKE
+
+# Add a custom.mk file to override any of the configurations
+-include custom.mk

--- a/lsp.ipkg
+++ b/lsp.ipkg
@@ -1,4 +1,5 @@
 package lsp
+version = 0.4.0
 
 depends = idris2, prelude, contrib
 

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -14,7 +14,6 @@ import Language.LSP.Message.Location
 import Language.LSP.Message.URI
 import Libraries.Data.PosMap
 import System.File
-import System.Clock
 
 ||| Label for the configuration reference.
 public export
@@ -52,9 +51,6 @@ record LSPConfiguration where
   cachedActions : PosMap (Range, IdrisAction, List CodeAction)
   ||| Cached hovers
   cachedHovers : PosMap (Range, Hover)
-  ||| Timeout in ms for long operations (currently stops multiple commands, e.g. ExprSearch)
-  ||| TODO: extend it to any operation and report the timeout, making it overridable
-  longActionTimeout : Clock Duration
   ||| next id for requests to the server
   nextRequestId : Nat
 
@@ -76,6 +72,5 @@ defaultConfig =
     , quickfixes        = []
     , cachedActions     = empty
     , cachedHovers      = empty
-    , longActionTimeout = makeDuration 5 0
     , nextRequestId     = 0
     }

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -211,6 +211,10 @@ handleRequest Initialize params = do
               Just (JNumber v) => setSearchTimeout $ cast v
               Just _ => logString Error "Incorrect type for long action timeout, expected number"
               Nothing => pure ()
+         case lookup "maxCodeActionResults" xs of
+              Just (JNumber v) => modify LSPConf (record { searchLimit = integerToNat $ cast v })
+              Just _ => logString Error "Incorrect type for max code action results, expected number"
+              Nothing => pure ()
        Just _ => logString Error "Incorrect type for initialization options"
        Nothing => pure ()
 

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -208,12 +208,7 @@ handleRequest Initialize params = do
               Just _ => logString Error "Incorrect type for log file location, expected string"
               Nothing => pure ()
          case lookup "longActionTimeout" xs of
-              Just (JNumber v) => do
-                let n = 1000000 * cast v
-                let scale       = 1000000000
-                let seconds     = n `div` scale
-                let nanoseconds = n `mod` scale
-                modify LSPConf (record {longActionTimeout = makeDuration seconds nanoseconds})
+              Just (JNumber v) => setSearchTimeout $ cast v
               Just _ => logString Error "Incorrect type for long action timeout, expected number"
               Nothing => pure ()
        Just _ => logString Error "Incorrect type for initialization options"


### PR DESCRIPTION
Replaces the old hack for timed out expression search/generate definition. This is much more precise since it can timeout also during a single search. Also use the new helper functions that generate the correct number of solution at once instead of using the REPL commands.