### PR TITLE
Send warnings

### DIFF
--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -171,7 +171,10 @@ loadURI conf uri version = do
   let caps = (publishDiagnostics <=< textDocument) . capabilities $ conf
   update LSPConf (record { quickfixes = [], cachedActions = empty, cachedHovers = empty })
   traverse_ (findQuickfix caps uri) errs
-  sendDiagnostics caps uri version errs
+  defs <- get Ctxt
+  session <- getSession
+  let warnings = if session.warningsAsErrors then [] else reverse (warnings defs)
+  sendDiagnostics caps uri version warnings errs
   pure $ Right ()
 
 loadIfNeeded : Ref LSPConf LSPConfiguration

--- a/src/Server/QuickFix.idr
+++ b/src/Server/QuickFix.idr
@@ -67,7 +67,7 @@ findQuickfix caps uri (InRHS _ _ err) = findQuickfix caps uri err
 findQuickfix caps uri (MaybeMisspelling err _) = findQuickfix caps uri err
 findQuickfix caps uri err@(PatternVariableUnifies fc env n tm) = do
   whenJust (isNonEmptyFC (getLoc tm)) $ \fc => do
-    diagnostic <- toDiagnostic caps uri err
+    diagnostic <- errorToDiagnostic caps uri err
     let textEdit = MkTextEdit (cast fc) (nameRoot n)
     let workspaceEdit = MkWorkspaceEdit { changes           = Just (singleton uri [textEdit])
                                         , documentChanges   = Nothing
@@ -89,7 +89,7 @@ findQuickfix caps uri err@(ValidCase fc _ (Left tm)) =
       | Nothing => do logE QuickFix "Error while fetching source line"
                       pure ()
     let line = unwords $ f :: args ++ ["=", "?\{f}_rhs_not_impossible"]
-    diagnostic <- toDiagnostic caps uri err
+    diagnostic <- errorToDiagnostic caps uri err
     let textEdit = MkTextEdit (cast fc) line
     let workspaceEdit = MkWorkspaceEdit { changes           = Just (singleton uri [textEdit])
                                         , documentChanges   = Nothing
@@ -112,7 +112,7 @@ findQuickfix caps uri err@(NotCovering fc n (MissingCases cs)) = do
     let endline = endLine fc
     src <- String.lines <$> getSource
     let blank = findBlankLine (drop (integerToNat (cast endline)) src) endline
-    diagnostic <- toDiagnostic caps uri err
+    diagnostic <- errorToDiagnostic caps uri err
     let range = MkRange (MkPosition blank 0) (MkPosition blank 0)
     let textEdit = MkTextEdit range cases
     let workspaceEdit = MkWorkspaceEdit { changes           = Just (singleton uri [textEdit])
@@ -146,7 +146,7 @@ findQuickfix caps uri err@(NotCovering fc n (MissingCases cs)) = do
     update LSPConf (record { quickfixes $= (\qf => missingCodeAction :: partialCodeAction :: qf) })
 findQuickfix caps uri err@(NotCovering fc n _) = do
   whenJust (isNonEmptyFC fc) $ \fc => do
-    diagnostic <- toDiagnostic caps uri err
+    diagnostic <- errorToDiagnostic caps uri err
     let startline = startLine fc
     let range = MkRange (MkPosition startline 0) (MkPosition startline 0)
     let textEdit = MkTextEdit range "partial\n"
@@ -166,7 +166,7 @@ findQuickfix caps uri err@(NotCovering fc n _) = do
     update LSPConf (record { quickfixes $= (codeAction ::) })
 findQuickfix caps uri err@(NotTotal fc n _) = do
   whenJust (isNonEmptyFC fc) $ \fc => do
-    diagnostic <- toDiagnostic caps uri err
+    diagnostic <- errorToDiagnostic caps uri err
     let startline = startLine fc
     let range = MkRange (MkPosition startline 0) (MkPosition startline 0)
     let textEdit = MkTextEdit range "covering\n"
@@ -185,4 +185,3 @@ findQuickfix caps uri err@(NotTotal fc n _) = do
                                   }
     update LSPConf (record { quickfixes $= (codeAction ::) })
 findQuickfix _ _ _ = pure ()
-

--- a/src/Server/Response.idr
+++ b/src/Server/Response.idr
@@ -129,10 +129,13 @@ sendDiagnostics : Ref LSPConf LSPConfiguration
                => (caps : Maybe PublishDiagnosticsClientCapabilities)
                -> (uri : DocumentURI)
                -> (version : Maybe Int)
+               -> (warnings : List Warning)
                -> (errs : List Error)
                -> Core ()
-sendDiagnostics caps uri version errs = do
-  diagnostics <- traverse (toDiagnostic caps uri) errs
+sendDiagnostics caps uri version warnings errs = do
+  warningDiagnostics <- traverse (warningToDiagnostic caps uri) warnings
+  errorDiagnostics <- traverse (errorToDiagnostic caps uri) errs
+  let diagnostics = warningDiagnostics ++ errorDiagnostics
   let params = MkPublishDiagnosticsParams uri version diagnostics
   logI Diagnostic "Sending diagnostic message for \{show uri}"
   sendNotificationMessage TextDocumentPublishDiagnostics params


### PR DESCRIPTION
This appears to initially work, but is not compressively tested. Because warnings are not written to TTC it only will work on first load, but that it an issue with idris2 not idris2-lsp.

Edit: This only works if there are errors in the file, because Idris 2 reloads from TTC if there are no warnings.