### PR TITLE
Exit on eof or error

### DIFF
--- a/src/Server/Utils.idr
+++ b/src/Server/Utils.idr
@@ -19,6 +19,7 @@ import Language.LSP.Message
 import Libraries.Data.PosMap
 import Server.Configuration
 import System.File
+import System
 
 ||| Gets a specific component of a reference, using the supplied projection.
 export
@@ -35,6 +36,8 @@ uncons' (x :: xs) = Just (x, xs)
 export
 fGetHeader : (handle : File) -> Core (Either FileError String)
 fGetHeader handle = do
+  False <- coreLift $ fEOF handle
+    | True => coreLift $ exitWith (ExitFailure 1)
   Right l <- coreLift $ fGetLine handle
     | Left err => pure $ Left err
   -- TODO: reading up to a string should probably be handled directly by the FFI primitive


### PR DESCRIPTION
I don't know if this is right, but it can now handle this without the run away memory issue.
```c
#include <stdio.h>

int main(int argc, const char * argv[]) {
    FILE *pipe = popen("~/.idris2/bin/idris2-lsp", "w");
    pclose(pipe);
    return 0;
}
```

This should fix #79 but I don't use NeoVim so someone else will have to test

We might want to consider looking out how Haskell's LSP does it:
https://github.com/haskell/lsp/blob/b9185cfe98f26a6937f774436b3dde266ca1fe2d/lsp-test/src/Language/LSP/Test/Decoding.hs