### PR TITLE
Allow user to configure IDRIS2 in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ TARGET = ${TARGETDIR}/${NAME}
 .PHONY: build
 
 build:
-	idris2 --build lsp.ipkg
+	$(IDRIS2) --build lsp.ipkg
 
 clean:
-	idris2 --clean lsp.ipkg
+	$(IDRIS2) --clean lsp.ipkg
 	$(RM) -r build
 
 repl:
-	rlwrap idris2 --repl lsp.ipkg
+	rlwrap $(IDRIS2) --repl lsp.ipkg
 
 testbin:
 	@${MAKE} -C tests testbin

--- a/config.mk
+++ b/config.mk
@@ -3,6 +3,9 @@
 # Where to install idris2 binaries and libraries (must be an absolute path)
 PREFIX ?= $(HOME)/.idris2
 
+# Idris 2 executable for building and installation. By default, just use whatever is in PATH.
+IDRIS2 ?= idris2
+
 # For Windows targets. Set to 1 to support Windows 7.
 OLD_WIN ?= 0
 


### PR DESCRIPTION
I found this modification useful, because I sometimes don't want to build with the `idris2` executable that happens to be first in `PATH` (e.g. if you have both a stable and unstable Git-master version installed).

The default behavior is the same, but now the user can specify `make IDRIS2=...` in order to change it.