### PR TITLE
Added metavars command

### DIFF
--- a/src/Language/LSP/Definition.idr
+++ b/src/Language/LSP/Definition.idr
@@ -18,6 +18,7 @@ import Server.Utils
 import System.File
 import System.Path
 
+export
 mkLocation : Ref Ctxt Defs
           => Ref LSPConf LSPConfiguration
           => OriginDesc -> (Int, Int) -> (Int, Int) -> Core (Maybe Location)

--- a/src/Language/LSP/Metavars.idr
+++ b/src/Language/LSP/Metavars.idr
@@ -1,0 +1,124 @@
+module Language.LSP.Metavars
+
+import Core.Context
+import Core.Core
+import Core.Directory
+import Core.Env
+import Core.TT
+import Core.Name
+import Idris.IDEMode.Holes
+import Idris.Pretty
+import Idris.Pretty.Render
+import Idris.REPL.Opts
+import Idris.Resugar
+import Idris.Syntax
+import Language.JSON
+import Language.LSP.Message
+import Language.LSP.Definition
+import Server.Configuration
+import Server.Utils
+import System.File
+import System.Path
+
+%hide Holes.HolePremise
+%hide Holes.HoleData
+%hide Holes.getUserHolesData
+
+-- Non-exported functions are temporary changes to functions in the module Idris.IDEMode.Holes.
+-- TODO: upstream changes to the compiler when stability is reached.
+
+record HolePremise where
+  constructor MkHolePremise
+  name         : Name
+  type         : IPTerm
+  multiplicity : RigCount
+  isImplicit   : Bool
+
+record HoleData where
+  constructor MkHoleData
+  name : Name
+  location : FC
+  type : IPTerm
+  context : List HolePremise
+
+showName : Name -> Bool
+showName (UN Underscore) = False
+showName (MN _ _) = False
+showName _ = True
+
+extractHoleData : {vars : _}
+               -> Ref Ctxt Defs
+               => Ref Syn SyntaxInfo
+               => Defs -> Env Term vars -> Name -> FC -> Nat -> Term vars
+               -> Core HoleData
+extractHoleData defs env fn fc (S args) (Bind _ _ (Let _ _ val _) sc) =
+  extractHoleData defs env fn fc args (subst val sc)
+extractHoleData defs env fn fc (S args) (Bind _ x b sc) = do
+  rest <- extractHoleData defs (b :: env) fn fc args sc
+  let True = showName x
+    | False => pure rest
+  ity <- resugar env !(normalise defs env (binderType b))
+  let premise = MkHolePremise x ity (multiplicity b) (isImplicit b)
+  pure $ record { context $= (premise ::) } rest
+extractHoleData defs env fn fc args ty = do
+  nty <- normalise defs env ty
+  ity <- resugar env nty
+  pure $ MkHoleData fn fc ity []
+
+holeData : {vars : _}
+        -> Ref Ctxt Defs
+        => Ref Syn SyntaxInfo
+        => Defs -> Env Term vars -> Name -> FC -> Nat -> Term vars ->
+           Core HoleData
+holeData gam env fn fc args ty = do
+  hdata <- extractHoleData gam env fn fc args ty
+  pp <- getPPrint
+  pure $ if showImplicits pp
+            then hdata
+            else record { context $= dropShadows } hdata
+  where
+    dropShadows : List HolePremise -> List HolePremise
+    dropShadows [] = []
+    dropShadows (premise :: rest) =
+      if premise.name `elem` map name rest
+         then            dropShadows rest
+         else premise :: dropShadows rest
+
+getUserHolesData : Ref Ctxt Defs
+                => Ref Syn SyntaxInfo
+                => Core (List HoleData)
+getUserHolesData = do
+  defs <- get Ctxt
+  let ctxt = gamma defs
+  ms  <- getUserHoles
+  let globs = concat !(traverse (\n => lookupCtxtName n ctxt) ms)
+  let holesWithArgs = mapMaybe (\(n, i, gdef) => pure (n, gdef, !(isHole gdef))) globs
+  traverse (\(n, gdef, args) => holeData defs [] n (location gdef) args (type gdef)) holesWithArgs
+
+||| Returns the list of metavariables visible in the current context with their location.
+||| JSON schema for a single metavariable:
+||| {
+|||   location: Location | null;
+|||   name: string;
+|||   type: string;
+||| }
+export
+metavarsCmd : Ref Ctxt Defs
+           => Ref Syn SyntaxInfo
+           => Ref ROpts REPLOpts
+           => Ref LSPConf LSPConfiguration
+           => Core JSON
+metavarsCmd = do
+  c <- getColor
+  setColor False
+  holes <- getUserHolesData
+  res <- for holes $ \h => do
+    loc <- case h.location of
+      MkFC f s e => mkLocation f s e
+      MkVirtualFC f s e => mkLocation f s e
+      _ => pure Nothing
+    let name = show h.name
+    type <- render (reAnnotate Syntax $ prettyTerm h.type)
+    pure $ JObject [("location", toJSON loc), ("name", toJSON name), ("type", toJSON type)]
+  setColor c
+  pure $ JArray res

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -36,6 +36,7 @@ import Language.LSP.Definition
 import Language.LSP.DocumentSymbol
 import Language.LSP.SignatureHelp
 import Language.LSP.Message
+import Language.LSP.Metavars
 import Libraries.Data.PosMap
 import Libraries.Data.Version
 import Libraries.Utils.Path
@@ -429,6 +430,8 @@ handleRequest WorkspaceExecuteCommand
     str <- render doc
     setColor c
     pure $ Right (JString str)
+handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "metavars" _) =
+  whenActiveRequest $ \conf => Right <$> metavarsCmd
 handleRequest method params = whenActiveRequest $ \conf => do
     logW Channel $ "Received a not supported \{show (toJSON method)} request"
     pure $ Left methodNotFound


### PR DESCRIPTION
The server now supports a new command `metavars`, callabe with a `workspace/executeCommand` request.
It returns the list of metavariables in the context (be either hole or declarations without definitions). The list is actually the same as `:metavars` in the REPL. Furthermore returns also the location of each metavariable so that clients can jump to location.
Each item has the following JSON schema:
```
{
  location: Location | null;
  name: string;
  type: string;
  premises: Premise[];
}
```
where the JSON schema of `Premise` is:
```
{
  location: Location | null;
  name: string;
  type: string;
  isImplicit: bool;
}
```