### PR TITLE
Dynamically change server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Server options that can be set via the `initializationOptions` object in the ini
 |`logFile`|`string`|Absolute location of the log file for the server (default: stderr)|
 |`longActionTimeout`|`number`|Timeout in ms for long actions, e.g. expression search (default: 5000)|
 |`maxCodeActionResults`|`number`|Maximum number of multiple code actions for a single command, e.g. expression search (default: 5)|
+|`showImplicits`|`boolean`|Show implicits in hovers|
+|`fullNamespace`|`boolean`|Show full namespace in hovers|
 
 ## Code Actions Filters
 As per specification, client can filter requested code actions with the `context.only` field in the request parameters.


### PR DESCRIPTION
Clients can now send a `workspace/didChangeConfiguration` notification to change server settings.
I've also exposed two settings already available in the REPL: `showImplicits` which always shows implicits when printing terms and `fullNamespace` which always shows the full namespace of names when printing.