### PR TITLE
Pretty print deprecated names

### DIFF
--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -12,6 +12,7 @@ import Idris.Pretty
 import Idris.REPL.Opts
 import Idris.Resugar
 import Idris.Syntax
+import Idris.Doc.String
 import Language.JSON
 import Language.LSP.Message
 import Parser.Support
@@ -117,7 +118,11 @@ pwarning (ShadowingGlobalDefs _ ns) =
                              :: reflow "is shadowing"
                              :: punctuate comma (map pretty (forget ns)))
              (forget ns)
-pwarning (Deprecated s n) = pure $ pretty "Deprecation warning:" <++> pretty s <++> pretty n
+pwarning (Deprecated s fcAndName) =
+  do docs <- traverseOpt (\(fc, name) => getDocsForName fc name justUserDoc) fcAndName
+     pure . vsep $ catMaybes [ Just $ pretty "Deprecation warning:" <++> pretty s
+                             , map (const UserDocString) <$> docs
+                             ]
 pwarning (GenericWarn s) = pure $ pretty s
 pwarning (ParserWarning fc msg) = pure $ pretty msg
 

--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -117,7 +117,7 @@ pwarning (ShadowingGlobalDefs _ ns) =
                              :: reflow "is shadowing"
                              :: punctuate comma (map pretty (forget ns)))
              (forget ns)
-pwarning (Deprecated s) = pure $ pretty "Deprecation warning:" <++> pretty s
+pwarning (Deprecated s n) = pure $ pretty "Deprecation warning:" <++> pretty s <++> pretty n
 pwarning (GenericWarn s) = pure $ pretty s
 pwarning (ParserWarning fc msg) = pure $ pretty msg
 


### PR DESCRIPTION
An extra arg was added to the `Deprecated` constructor here:

https://github.com/idris-lang/Idris2/pull/2086/files#diff-a50d7624d92d7510ce48f414ef787bd626c776a1bdb70bfad3421f6dbb286b39R73

Not sure if we should be pretty printing this, or just ignoring it with
`_`, as I'm not sure how to test what this looks like. But at any rate
it's now compiling with the latest idris (`0.5.1-686a52fb0`).