### PR TITLE
Add command for Refine Hole/Expr Search with hints

### DIFF
--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -265,6 +265,10 @@ perror (AllFailed ts)
     allUndefined _ = Nothing
 perror (RecordTypeNeeded fc _)
     = pure $ errorDesc (reflow "Can't infer type for this record update.")
+perror (DuplicatedRecordUpdatePath fc ps)
+    = pure $ vcat $
+        errorDesc (reflow "Duplicated record update paths:")
+          :: map (indent 2 . concatWith (surround (pretty "->")) . map pretty) ps
 perror (NotRecordField fc fld Nothing)
     = pure $ errorDesc (code (pretty fld) <++> reflow "is not part of a record type.")
 perror (NotRecordField fc fld (Just ty))

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -452,6 +452,26 @@ handleRequest WorkspaceExecuteCommand
 handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "metavars" _) = whenActiveRequest $ \conf => do
   logI Channel "Received metavars command request"
   Right <$> metavarsCmd
+handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "exprSearchWithHints" (Just [json])) = whenActiveRequest $ \conf => do
+  logI Channel "Received exprSearchWithHints command request"
+  let JObject obj = json
+    | _ => pure $ Left (invalidParams "Expected Object")
+  let Just params = fromJSON {a = CodeActionParams} =<< lookup "codeAction" obj
+    | _ => pure $ Left (invalidParams "Expected CodeActionParams")
+  let Just hints = fromJSON {a = List String} =<< lookup "hints" obj
+    | _ => pure $ Left (invalidParams "Expected String[]")
+  actions <- exprSearchWithHints params hints
+  pure $ Right (toJSON actions)
+handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "refineHoleWithHints" (Just [json])) = whenActiveRequest $ \conf => do
+  logI Channel "Received refineHoleWithHints command request"
+  let JObject obj = json
+    | _ => pure $ Left (invalidParams "Expected Object")
+  let Just params = fromJSON {a = CodeActionParams} =<< lookup "codeAction" obj
+    | _ => pure $ Left (invalidParams "Expected CodeActionParams")
+  let Just hints = fromJSON {a = List String} =<< lookup "hints" obj
+    | _ => pure $ Left (invalidParams "Expected String[]")
+  actions <- refineHoleWithHints params hints
+  pure $ Right (toJSON actions)
 handleRequest method params = whenActiveRequest $ \conf => do
     logW Channel $ "Received a not supported \{show (toJSON method)} request"
     pure $ Left methodNotFound


### PR DESCRIPTION
CodeAction by specification do not allow additional information to be sent on the line. Thus I've added two commands for the Refine Hole and the Expression Search interactive commands, that still take a `CodeActionParams` object as argument, but also a list of strings as hints for the search. Both returns messages compatible with CodeAction response messages.
Since refine hole already tries to search for compatible functions and also uses the name of the hole as hint, when the user explicitly passes one or more hints, not only they would be the only custom hints available, but results will be filtered by the usage of such hints. An example would be suggesting a particular function, and the response would be an application of such function with compatible arguments or new metavariables.