### PR TITLE
Fix unescaped chars in URIs

### DIFF
--- a/src/Language/LSP/Definition.idr
+++ b/src/Language/LSP/Definition.idr
@@ -45,7 +45,7 @@ mkLocation origin (sline, scol) (eline, ecol) = do
 
   let fname_abs_uri = "file://" ++ fname_abs
 
-  let Right (uri, _) = parse uriReferenceParser fname_abs_uri
+  let Right uri = escapeAndParseURI fname_abs_uri
     | Left err => do logE GotoDefinition "URI parse error: \{err} \{show (fname_abs_uri, sline, scol)}"
                      pure Nothing
 


### PR DESCRIPTION
File locations stored in the context contains character that must be escoped in URI form. These locations produced the wrong URI when parsed and thus the server sent wrong URI on the channel, causing failures for commands like jump to definition. An example of wrongful locations are those with spaces in their names, which are stored with spaces in the context but need to be converted to `%20` sequences instead.