### PR TITLE
Add command to browse a specific namespace

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -179,3 +179,28 @@ export interface RefineHoleHints {
 _Response_:
   - result: `CodeAction[] | null`.
   - error: code and message set in case an exception happens during the request.
+
+## BrowseNamespace Request
+
+The browseNamespace request is sent from the client to the server to return the list
+of visible names found in a given namespace.
+
+_Request_:
+  - method: 'workspace/executeCommand'
+  - params: `BrowseNamespaceParams` defined as follows:
+```typescript
+export interface BrowseNamespaceParams {
+  /**
+   * The identifier of the actual command handler.
+   */
+  command: 'browseNamespace';
+  /**
+   * List of namespaces. Currently supports a single object.
+   */
+  arguments: string[];
+}
+```
+
+_Response_:
+  - result: `SymbolInformation[]`.
+  - error: code and message set in case an exception happens during the request.

--- a/src/Language/LSP/BrowseNamespace.idr
+++ b/src/Language/LSP/BrowseNamespace.idr
@@ -1,0 +1,87 @@
+module Language.LSP.BrowseNamespace
+
+import Core.Context
+import Core.Core
+import Core.Env
+import Core.Metadata
+import Core.Name
+import Data.List
+import Idris.Doc.String
+import Idris.REPL.Opts
+import Idris.Resugar
+import Idris.Syntax
+import Language.LSP.Definition
+import Language.LSP.Message
+import Libraries.Data.NameMap
+import Parser.Source
+import Parser.Rule.Source
+import Server.Configuration
+import Server.Log
+import Server.Utils
+
+visible : Defs -> Name -> Core Bool
+visible defs n = do 
+  Just def <- lookupCtxtExact n (gamma defs)
+    | Nothing => pure False
+  pure $ visibility def /= Private
+
+inNS : Namespace -> Name -> Bool
+inNS ns (NS xns (UN _)) = ns `isParentOf` xns
+inNS _ _ = False
+
+getNames : Ref ROpts REPLOpts
+        => Ref Ctxt Defs
+        => Ref Syn SyntaxInfo
+        => Namespace -> Core (List Name)
+getNames ns = do
+  defs <- get Ctxt
+  names <- allNames defs.gamma
+  let allNames = filter (inNS ns) names
+  allNames <- filterM (visible defs) allNames
+  pure $ sort allNames
+
+buildDocumentSymbol : Ref Ctxt Defs
+                   => Ref LSPConf LSPConfiguration
+                   => Ref Syn SyntaxInfo
+                   => Name -> Core (Maybe SymbolInformation)
+buildDocumentSymbol n = do
+  defs <- get Ctxt
+  Just def <- lookupCtxtExact n defs.gamma
+    | _ => pure Nothing
+  Just loc <- mkLocation def.location
+    | _ => pure Nothing
+  let isDeprecated = Deprecate `elem` def.flags
+  let kind = case def.definition of
+                  (PMDef {}) => Function
+                  (ExternDef {}) => Function
+                  (ForeignDef {}) => Function
+                  (Builtin {}) => Function
+                  (DCon {}) => EnumMember
+                  (TCon {}) => Constructor
+                  (Hole {}) => Variable
+                  _ => Null
+  ty <- resugar [] =<< normaliseHoles defs [] def.type
+  pure $ Just $ MkSymbolInformation
+    { name = "\{show $ dropNS n} : \{show ty}"
+    , kind = kind
+    , tags = if isDeprecated then Just [Deprecated] else Nothing
+    , deprecated = Nothing
+    , location = loc
+    , containerName = Nothing
+    }
+
+||| Returns the list of functions visible in the given namespace.
+||| The response in the same format as a textDocument/documentSymbol request.
+export
+browseNamespaceCmd : Ref Ctxt Defs
+                  => Ref Syn SyntaxInfo
+                  => Ref ROpts REPLOpts
+                  => Ref LSPConf LSPConfiguration
+                  => String -> Core (List SymbolInformation)
+browseNamespaceCmd str = do
+  let Right (_, _, ns) = runParser (Virtual Interactive) Nothing str namespaceId
+    | _ => pure []
+  logI Browse "Browsing namespace \{show ns}"
+  names <- getNames ns
+  logI Browse "Names in \{show ns} fetched, found \{show $ length names}"
+  catMaybes <$> traverse buildDocumentSymbol names

--- a/src/Language/LSP/DocumentSymbol.idr
+++ b/src/Language/LSP/DocumentSymbol.idr
@@ -42,11 +42,11 @@ currentNSNameWithLoc namespaces name = do
     MkFC        _ start end => Just (gdef.fullname, start, end)
     MkVirtualFC _ start end => Just (gdef.fullname, start, end)
 
-buildSymbolInformation : Name -> URI -> FileRange -> SymbolKind -> SymbolInformation
-buildSymbolInformation n uri range kind = MkSymbolInformation
+buildSymbolInformation : Name -> URI -> FileRange -> SymbolKind -> Bool -> SymbolInformation
+buildSymbolInformation n uri range kind deprecated = MkSymbolInformation
   { name = show $ dropNS n
   , kind = kind
-  , tags = Nothing
+  , tags = if deprecated then Just [Deprecated] else Nothing
   , deprecated = Nothing
   , location = MkLocation uri (cast range)
   , containerName = Nothing
@@ -74,9 +74,9 @@ documentSymbol params = do
   let knownNames = NameMap.keys $ namesResolvedAs defs.gamma
   -- Render global and meta names as SymbolInformation
   visibleNames <- map catMaybes $ traverse (currentNSNameWithLoc currentNamespaces) knownNames
-  let globalDocSymbols = map (\(n, range) => buildSymbolInformation n uri range Function) visibleNames
+  let globalDocSymbols = map (\(n, range) => buildSymbolInformation n uri range Function False) visibleNames
   meta <- get MD
-  let metaDocSymbols = map (\((_, range), (metaName, _, _)) => buildSymbolInformation metaName uri range Variable) meta.names
+  let metaDocSymbols = map (\((_, range), (metaName, _, _)) => buildSymbolInformation metaName uri range Variable False) meta.names
   let docSymbols = globalDocSymbols ++ metaDocSymbols
   logI DocumentSymbol "Found \{show (length globalDocSymbols)} global and \{show (length metaDocSymbols)} meta document symbols."
   pure $ docSymbols

--- a/src/Server/Log.idr
+++ b/src/Server/Log.idr
@@ -55,6 +55,7 @@ Ord Severity where
 public export
 data Topic
   = AddClause
+  | Browse
   | CaseSplit
   | Channel
   | CodeAction
@@ -78,6 +79,7 @@ data Topic
 export
 Show Topic where
   show AddClause = "Request.CodeAction.AddClause"
+  show Browse = "Request.Command.Browse"
   show CaseSplit = "Request.CodeAction.CaseSplit"
   show Channel = "Communication.Channel"
   show CodeAction = "CodeAction"

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -24,6 +24,7 @@ import Idris.REPL.Opts
 import Idris.Resugar
 import Idris.Syntax
 import Language.JSON
+import Language.LSP.BrowseNamespace
 import Language.LSP.CodeAction
 import Language.LSP.CodeAction.AddClause
 import Language.LSP.CodeAction.CaseSplit
@@ -472,6 +473,12 @@ handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "refineHoleWithH
     | Nothing => pure $ Left (invalidParams "Expected RefineHoleWithHintsParams")
   actions <- refineHoleWithHints params
   pure $ Right (toJSON actions)
+handleRequest WorkspaceExecuteCommand (MkExecuteCommandParams _ "browseNamespace" (Just [json])) = whenActiveRequest $ \conf => do
+  logI Channel "Received browseNamespace command request"
+  let Just params = fromJSON {a = String} json
+    | Nothing => pure $ Left (invalidParams "Expected String")
+  names <- browseNamespaceCmd params
+  pure $ Right (toJSON names)
 handleRequest method params = whenActiveRequest $ \conf => do
     logW Channel $ "Received a not supported \{show (toJSON method)} request"
     pure $ Left methodNotFound


### PR DESCRIPTION
This command mirrors the functionality of the `:browse` command in the compiler REPL.
The return message schema is the same as the `textDocument/documentSymbol`.