### PR TITLE
Make LSP Types installable as a library

### DIFF
--- a/lsp.ipkg
+++ b/lsp.ipkg
@@ -1,11 +1,56 @@
 package lsp
-version = 0.4.0
+version = 0.5.0
 
 opts = "-Wno-shadowing"
 
-depends = idris2, prelude, contrib
+depends = idris2, contrib
 
 sourcedir = "src"
 
 main = Server.Main
 executable = idris2-lsp
+
+modules = Data.URI
+        , Language.JSON.Interfaces
+        , Language.LSP.Message
+        , Language.LSP.Message.CallHierarchy
+        , Language.LSP.Message.Cancel
+        , Language.LSP.Message.ClientCapabilities
+        , Language.LSP.Message.CodeAction
+        , Language.LSP.Message.CodeLens
+        , Language.LSP.Message.Command
+        , Language.LSP.Message.Completion
+        , Language.LSP.Message.Declaration
+        , Language.LSP.Message.Definition
+        , Language.LSP.Message.Derive
+        , Language.LSP.Message.Diagnostics
+        , Language.LSP.Message.DocumentColor
+        , Language.LSP.Message.DocumentFormatting
+        , Language.LSP.Message.DocumentHighlight
+        , Language.LSP.Message.DocumentLink
+        , Language.LSP.Message.DocumentSymbols
+        , Language.LSP.Message.FoldingRange
+        , Language.LSP.Message.Hover
+        , Language.LSP.Message.Implementation
+        , Language.LSP.Message.Initialize
+        , Language.LSP.Message.LinkedEditingRange
+        , Language.LSP.Message.Location
+        , Language.LSP.Message.Markup
+        , Language.LSP.Message.Message
+        , Language.LSP.Message.Method
+        , Language.LSP.Message.Moniker
+        , Language.LSP.Message.Progress
+        , Language.LSP.Message.References
+        , Language.LSP.Message.Registration
+        , Language.LSP.Message.RegularExpressions
+        , Language.LSP.Message.Rename
+        , Language.LSP.Message.SelectionRange
+        , Language.LSP.Message.SemanticTokens
+        , Language.LSP.Message.ServerCapabilities
+        , Language.LSP.Message.SignatureHelp
+        , Language.LSP.Message.TextDocument
+        , Language.LSP.Message.Trace
+        , Language.LSP.Message.URI
+        , Language.LSP.Message.Utils
+        , Language.LSP.Message.Window
+        , Language.LSP.Message.Workspace

--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -15,6 +15,7 @@ import Idris.Syntax
 import Idris.Doc.String
 import Language.JSON
 import Language.LSP.Message
+import Libraries.Data.String.Extra
 import Parser.Support
 import Server.Configuration
 import Server.Log

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -42,6 +42,7 @@ import Language.LSP.Metavars
 import Language.LSP.SignatureHelp
 import Libraries.Data.List.Extra
 import Libraries.Data.PosMap
+import Libraries.Data.String.Extra
 import Libraries.Data.Version
 import Libraries.Utils.Path
 import Parser.Unlit
@@ -449,7 +450,7 @@ handleRequest TextDocumentSemanticTokensFull params = whenActiveRequest $ \conf 
     withURI conf params.textDocument.uri Nothing (pure $ Left (MkResponseError RequestCancelled "Document Errors" JNull)) $ do
       md <- get MD
       src <- getSource
-      let srcLines = forget $ lines src
+      let srcLines = lines src
       let getLineLength = \lineNum => maybe 0 (cast . length) $ elemAt srcLines (integerToNat (cast lineNum))
       tokens <- getSemanticTokens md getLineLength
       update LSPConf ({ semanticTokensSentFiles $= insert params.textDocument.uri })


### PR DESCRIPTION
The `Language.LSP.Message` namespace is now exported in the ipkg, therefore it can be installed and used as a library. Also updated the supported compiler version.