### PR TITLE
Fixed issue with document highlight origin

### DIFF
--- a/src/Language/LSP/DocumentHighlight.idr
+++ b/src/Language/LSP/DocumentHighlight.idr
@@ -36,10 +36,10 @@ documentHighlights params = do
   let line = params.position.line
   let col  = params.position.character
   nameLocs <- gets MD nameLocMap
-  let Just (_, name) = findPointInTreeLoc (line, col) nameLocs
+  let Just ((origin, _, _), name) = findPointInTreeLoc (line, col) nameLocs
     | Nothing => logD DocumentHighlight "No name found at \{show line}:\{show col}}" >> pure []
   logI DocumentHighlight "Found name \{show name}"
 
-  matchingNames <- gets MD (nub . map fst . filter ((==) name . snd) . toList . nameLocMap)
+  matchingNames <- gets MD (nub . map fst . filter (\((o, _, _), n) => o == origin && n == name) . toList . nameLocMap)
   logI DocumentHighlight "Found \{show $ length matchingNames} matches"
   pure (makeHighlight <$> matchingNames)


### PR DESCRIPTION
Sometimes the metadata for a given name contains location from other origins, this caused issues with the `textDocument/documentHighlight` command, at least in the neovim client.