### PR TITLE
[ build ] add prebuild hook to ipkg file

### DIFF
--- a/lsp.ipkg
+++ b/lsp.ipkg
@@ -54,3 +54,5 @@ modules = Data.URI
         , Language.LSP.Message.Utils
         , Language.LSP.Message.Window
         , Language.LSP.Message.Workspace
+
+prebuild = "make src/Server/Generated.idr"


### PR DESCRIPTION
I'd like to make idris2-lsp usable from within the [pack](https://github.com/stefan-hoeck/idris2-pack) package manager. The steps necessary for this are minimal: We have to add a custom build hook to the `.ipkg` file, so that `idris2 --build lsp.ipkg` will also generate file `Server.Generated.idr` automatically.