### PR TITLE
Disable hover caching

### DIFF
--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -351,7 +351,8 @@ handleRequest TextDocumentHover params = whenActiveRequest $ \conf => do
                                                then MkMarkupContent Markdown $ "```idris\n\{line}\n```"
                                                else MkMarkupContent PlainText line
     let hover = MkHover (make markupContent) Nothing
-    update LSPConf ({ cachedHovers $= insert (cast loc, hover) })
+    -- TODO consider reenabling hover caching once locations are accurate
+    -- update LSPConf ({ cachedHovers $= insert (cast loc, hover) })
     pure $ pure (make hover)
 
 handleRequest TextDocumentDocumentHighlight params = whenActiveRequest $ \conf => do


### PR DESCRIPTION
```idris
test : ()
test = case True of
    True => ()
    False => ()
           1  2
```

Tigger hover at `1`, then at `2`. You will see the wrong value, disabling the hover cache fixes this. There is probably a better way to handle this, but it should be disabled until then. 