### PR TITLE
Fixed resolution error in repl command after reload

### DIFF
--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -187,6 +187,7 @@ loadURI conf uri version = do
   defs <- get Ctxt
   let extraDirs = defs.options.dirs.extra_dirs
   update LSPConf ({ openFile := Just (uri, fromMaybe 0 version) })
+  update ROpts { evalResultName := Nothing }
   resetContext (Virtual Interactive)
   let fpath = uri.path
   let Just (startFolder, startFile) = splitParent fpath


### PR DESCRIPTION
`repl` commands could fail after a reload. This fixes the issue.

To reproduce:
- Send a `repl` command
- Modify and save a file
- Send another `repl` command