### PR TITLE
Swap out unlines use now that unlines adds a newline at the end.

### DIFF
--- a/src/Language/LSP/CodeAction/CaseSplit.idr
+++ b/src/Language/LSP/CodeAction/CaseSplit.idr
@@ -73,5 +73,5 @@ caseSplit params = do
                         pure Nothing
 
       let rng = MkRange (MkPosition line 0) (MkPosition line (cast (length original)))
-      let edit = MkTextEdit rng (unlines lines)
+      let edit = MkTextEdit rng (joinBy "\n" lines)
       pure $ Just (cast loc, buildCodeAction params.textDocument.uri name edit)


### PR DESCRIPTION
Ever since `unlines` changed to add a newline at the end of the list of input strings in addition to between each element, the case split action has resulted in extra newlines between function clauses.

Given the following definition:
```Idris
hi : Nat -> Nat -> Nat
hi k 0 = ?hi_rhs_0
hi k (S j) = ?hi_rhs_1
```

Before this PR, case splitting on `k` in first clause:
```idris
hi : Nat -> Nat -> Nat
hi 0 0 = ?hi_rhs_2
hi (S k) 0 = ?hi_rhs_3

hi k (S j) = ?hi_rhs_1
```

After this PR, case splitting on `k` in first clause:
```idris
hi : Nat -> Nat -> Nat
hi 0 0 = ?hi_rhs_2
hi (S k) 0 = ?hi_rhs_3
hi k (S j) = ?hi_rhs_1
```