### PR TITLE
Add windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cd .. # Go back to the idris2-lsp directory
 make install # Install idris2-lsp
 ```
 
+Can be installed on Windows via MSYS2.
+
 ## Editor Plugins
 - VSCode: [idris2-lsp-vscode](https://github.com/bamboo/idris2-lsp-vscode)
 - Neovim: [idris2-nvim](https://github.com/ShinKage/idris2-nvim)

--- a/src/Language/LSP/Definition.idr
+++ b/src/Language/LSP/Definition.idr
@@ -40,7 +40,7 @@ mkLocation' origin (sline, scol) (eline, ecol) = do
         pure (pkg_dir_abs </> toPath modIdent <.> ext))
     | _ => logD GotoDefinition "Can't find file for module \{show modIdent}" >> pure Nothing
 
-  let fname_abs_uri = "file://\{fname_abs}"
+  let fname_abs_uri = "file://\{systemPathToURIPath fname_abs}"
 
   -- Escape is needed, filename may contain characters reserved in URI, like whitespace
   let Right uri = escapeAndParseURI fname_abs_uri

--- a/src/Server/Diagnostics.idr
+++ b/src/Server/Diagnostics.idr
@@ -122,7 +122,7 @@ warningToDiagnostic caps uri warning = do
   let wdir = defs.options.dirs.working_dir
   p <- maybe (pure uri.path) (pure . (wdir </>) <=< nsToSource replFC)
          ((\case PhysicalIdrSrc ident => Just ident; _ => Nothing) . fst <=< isNonEmptyFC =<< loc)
-  if uri.path == p
+  if System.Path.parse (uriPathToSystemPath uri.path) == System.Path.parse p
      then do let related = Nothing -- TODO related diagnostics?
              pure $ buildDiagnostic Warning loc warningAnn related
      else pure $ buildDiagnostic Warning (toStart <$> loc) ("In" <++> pretty0 p <+> colon <++> warningAnn) Nothing
@@ -148,7 +148,7 @@ errorToDiagnostic caps uri err = do
   let wdir = defs.options.dirs.working_dir
   p <- maybe (pure uri.path) (pure . (wdir </>) <=< nsToSource replFC)
          ((\case PhysicalIdrSrc ident => Just ident; _ => Nothing) . fst <=< isNonEmptyFC =<< loc)
-  if uri.path == p
+  if System.Path.parse (uriPathToSystemPath uri.path) == System.Path.parse p
      then do let related = (flip toMaybe (getRelatedErrors uri err) <=< relatedInformation) =<< caps
              pure $ buildDiagnostic Error loc error related
      else pure $ buildDiagnostic Error (toStart <$> loc) ("In" <++> pretty0 p <+> colon <++> error) Nothing

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -43,9 +43,9 @@ Show Header where
 
 headerPart : List Header -> String
 headerPart [] = ""
-headerPart (ContentLength l :: xs) = "Content-Length: " ++ show l ++ "\r\n" ++ headerPart xs
-headerPart (ContentType s :: xs) = "Content-Type: " ++ s ++ "\r\n" ++ headerPart xs
-headerPart (StartContent :: _) = "\r\n"
+headerPart (ContentLength l :: xs) = "Content-Length: " ++ show l ++ headerLineEnd ++ headerPart xs
+headerPart (ContentType s :: xs) = "Content-Type: " ++ s ++ headerLineEnd ++ headerPart xs
+headerPart (StartContent :: _) = headerLineEnd
 
 parseHeader : String -> Maybe Header
 parseHeader "\r\n" = Just StartContent

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -189,7 +189,7 @@ loadURI conf uri version = do
   update LSPConf ({ openFile := Just (uri, fromMaybe 0 version) })
   update ROpts { evalResultName := Nothing }
   resetContext (Virtual Interactive)
-  let fpath = uri.path
+  let fpath = uriPathToSystemPath uri.path
   let Just (startFolder, startFile) = splitParent fpath
     | Nothing => do let msg = "Cannot find the parent folder for \{show uri}"
                     logE Server msg

--- a/src/Server/Response.idr
+++ b/src/Server/Response.idr
@@ -25,7 +25,7 @@ import System.File
 ||| Header for messages on-the-wire.
 ||| By specification only Content-Length is mandatory.
 header : Int -> String
-header l = "Content-Length: \{show l}\r\n\r\n"
+header l = "Content-Length: \{show l}\{headerLineEnd}\{headerLineEnd}"
 
 ||| Response message for method not found or not implemented yet.
 export


### PR DESCRIPTION
These are the changes i've been using on windows, based on the discussion in #77 (which never fully worked for me)

It's mainly two things:
- `headerLineEnd`, to handle the fact that windows silently adds the `\r` itself.
- `systemPathToURIPath` and `uriPathToSystemPath`, which on windows convert between `\` and `/`, and add/remove a starting `/`, and on non-windows just return the string unchanged.
Note: these names may be slightly confusing as the return value of `systemPathToURIPath` isn't necessarily a valid uri path, but a path that `escapeAndParseURI` can parse.

I don't know if this is really the *best* way to do this, and i'm not sure i've tracked down everything that needs to be changed, but everything *seems* to work, and i've confirmed that it works on both windows and linux.