### PR TITLE
[log] Lazy logging and severity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Server options that can be set via the `initializationOptions` object in the ini
 |Option key|Type|Description|
 |----------|----|-----------|
 |`logFile`|`string`|Absolute location of the log file for the server (default: stderr)|
+|`logSeverity`|`string`|Logs a string with the provided severity level (default: Debug)|
 |`longActionTimeout`|`number`|Timeout in ms for long actions, e.g. expression search (default: 5000)|
 |`maxCodeActionResults`|`number`|Maximum number of multiple code actions for a single command, e.g. expression search (default: 5)|
 |`showImplicits`|`boolean`|Show implicits in hovers|

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -15,6 +15,7 @@ import Language.LSP.Message.Location
 import Language.LSP.Message.URI
 import Language.LSP.Message.SemanticTokens
 import public Libraries.Data.PosMap
+import Server.Severity
 import System.File
 
 ||| Label for the configuration reference.
@@ -31,6 +32,8 @@ record LSPConfiguration where
   outputHandle : File
   ||| File handle where to put log messages.
   logHandle : File
+  ||| Level of logging; everything lighter than this will be ignored.
+  logSeverity : Severity
   ||| If the initialization protocol has succeded, it contains the client configuration.
   ||| @see https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#initialize
   initialized : Maybe InitializeParams
@@ -64,6 +67,7 @@ defaultConfig =
     { inputHandle             = stdin
     , outputHandle            = stdout
     , logHandle               = stderr
+    , logSeverity             = Debug
     , initialized             = Nothing
     , isShutdown              = False
     , openFile                = Nothing

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -52,6 +52,7 @@ import Server.Capabilities
 import Server.Configuration
 import Server.Diagnostics
 import Server.Log
+import Server.Severity
 import Server.QuickFix
 import Server.Response
 import Server.SemanticTokens
@@ -167,6 +168,11 @@ processSettings (JObject xs) = do
            setPPrint ({ showMachineNames := b } pp)
            update LSPConf ({ cachedHovers := empty })
        Just _ => logE Configuration "Incorrect type for show machine names, expected boolean"
+       Nothing => pure ()
+  case lookup "logSeverity" xs of
+       Just (JString ll) =>
+         whenJust (parseSeverity ll) $ \l => update LSPConf ({ logSeverity := l})
+       Just _ => logE Configuration "Incorrect type for log severity, expected string"
        Nothing => pure ()
 processSettings _ = logE Configuration "Incorrect type for options"
 

--- a/src/Server/Severity.idr
+++ b/src/Server/Severity.idr
@@ -1,0 +1,56 @@
+||| Logging utilities for the LSP server implementation.
+|||
+||| (C) The Idris Community, 2023
+module Server.Severity
+
+import Data.String
+
+%default total
+
+||| Type for the severity of logging messages.
+||| Levels are roughly categorised as follow:
+||| - Debug    Messages targeted only for developing purposes
+||| - Info     Messages for progress without unexpected behaviour or errors
+||| - Warning  Messages for unsupported requests or wrong configurations 
+||| - Error    Messages for either server or compiler error which are unexpected but recoverable
+||| - Critical Messages for error that require immediate stopping of the server
+public export
+data Severity = Debug | Info | Warning | Error | Critical
+
+export
+parseSeverity : String -> Maybe Severity
+parseSeverity str = case toUpper str of
+  "DEBUG"    => Just Debug
+  "INFO"     => Just Info
+  "WARNING"  => Just Warning
+  "ERROR"    => Just Error
+  "CRITICAL" => Just Critical
+  _          => Nothing
+
+Cast Severity Integer where
+  cast Debug    = 0
+  cast Info     = 1
+  cast Warning  = 2
+  cast Error    = 3
+  cast Critical = 4
+
+export
+Eq Severity where
+  Debug    == Debug    = True
+  Info     == Info     = True
+  Warning  == Warning  = True
+  Error    == Error    = True
+  Critical == Critical = True
+  _ == _ = False
+
+export
+Show Severity where
+  show Debug    = "DEBUG"
+  show Info     = "INFO"
+  show Warning  = "WARNING"
+  show Error    = "ERROR"
+  show Critical = "CRITICAL"
+
+export
+Ord Severity where
+  compare x y = compare (cast {to = Integer} x) (cast y)


### PR DESCRIPTION
Introduces lazy logging with severity checking. 

The client can set its desired log severity level using the `logSeverity` field in the initialization parameters. In regular LSP operation, the logs should only show errors and critical. During the development of the LSP itself, I would like to see all the related information. Before this PR, the only way to achieve this was the recompilation of the LSP server itself.