### PR TITLE
[ feature ] Completion request

### DIFF
--- a/src/Language/LSP/Completion/Handler.idr
+++ b/src/Language/LSP/Completion/Handler.idr
@@ -1,0 +1,237 @@
+module Language.LSP.Completion.Handler
+
+import Core.Context
+import Core.Core
+import Core.Env
+import Core.Metadata
+import Core.Name
+import Data.List
+import Data.Maybe
+import Data.SortedMap
+import Data.String
+import Idris.Doc.String
+import Idris.Pretty.Annotations
+import Idris.REPL.Opts
+import Idris.Syntax
+import Language.JSON.Data
+import Language.LSP.Completion.Info
+import Language.LSP.Message
+import Libraries.Data.NameMap
+import Libraries.Data.UserNameMap
+import Server.Configuration
+import Server.Log
+import Server.Utils
+import Server.VirtualDocument
+
+%default total
+
+-- When a file is opened the context is filled with definitions.
+-- 
+-- Cache names from opened files.
+-- Update cache on saving a file.
+-- Remove cache on closing a file.
+--
+-- TODO: Don't suggest on comment lines.
+
+config : Config
+config = MkConfig
+  {showType     = False}
+  {longNames    = True}
+  {dropFirst    = False}
+  {getTotality  = True}
+
+safeTail : List a -> List a
+safeTail []        = []
+safeTail (x :: xs) = xs
+
+number : List a -> List (Nat, a)
+number = go 0 []
+  where
+    go : Nat -> List (Nat, a) -> List a -> List (Nat, a)
+    go n ys []        = reverse ys
+    go n ys (x :: xs) = go (S n) ((n,x) :: ys) xs
+
+argument : Name -> Maybe String
+argument n =
+  let sn : Name := dropNS n in
+  if (isUserName sn)
+    then Just $ show sn
+    else Nothing
+
+arguments : Term vars -> List (Maybe String)
+arguments (Bind fc n (Pi   fc1 rig Explicit ty) scope) = argument n :: arguments scope
+arguments (Bind fc n (Lam  fc1 rig Explicit ty) scope) = argument n :: arguments scope
+arguments (Bind fc n (PVar fc1 rig Explicit ty) scope) = argument n :: arguments scope
+arguments (Bind fc x (Lam  fc1 rig pinfo    ty) scope) = arguments scope
+arguments (Bind fc x (Let  fc1 rig val      ty) scope) = arguments scope
+arguments (Bind fc x (Pi   fc1 rig pinfo    ty) scope) = arguments scope
+arguments (Bind fc x (PVar fc1 rig pinfo    ty) scope) = arguments scope
+arguments (Bind fc x (PLet fc1 rig val      ty) scope) = arguments scope
+arguments (Bind fc x (PVTy fc1 rig          ty) scope) = arguments scope
+arguments (As       fc side as pat)                    = arguments pat
+arguments (TDelayed fc lz t)                           = arguments t
+arguments (TDelay   fc lz ty arg)                      = arguments arg
+arguments (TForce   fc lz t)                           = arguments t
+arguments (App fc fn arg)                              = safeTail (arguments fn)
+arguments (Local fc isLet idx p)                       = []
+arguments (Ref fc nt name)                             = []
+arguments (Meta fc n i ts)                             = []
+arguments (PrimVal fc c)                               = []
+arguments (Erased fc why)                              = []
+arguments (TType fc n)                                 = []
+
+export
+covering
+completionNames : Ref Ctxt Defs
+               => Ref LSPConf LSPConfiguration
+               => Ref Syn SyntaxInfo
+               => Ref ROpts REPLOpts
+               => Core (SortedMap NameCategory (List Entry))
+completionNames = do
+  defs <- get Ctxt
+  let ctxt = gamma defs
+  let namespaces = sort $ nub (currentNS defs :: nestedNS defs ++ map (snd . snd) (imported defs))
+  logD Completion "Found namespaces: \{unwords (map show namespaces)}"
+  let categorizeName
+        : (Namespace, UserName, Name) -> NameCategory
+        := \(ns,un,n) =>
+            if isJust (isField un)
+              then FieldName
+              else if currentNS defs == ns
+                then CurrentNsName
+                else if elem ns (nestedNS defs)
+                  then InNestedNs
+                  else OtherName
+  let inImportedNamespaces = mapMaybe (accessibleName namespaces) $ keys $ resolvedAs ctxt
+  visibleExportedNames <- traverse
+    (\(ns, un, n) => do
+        mdef <- lookupCtxtExact n ctxt
+        case mdef of
+          Nothing => pure Nothing
+          Just def => 
+            let visible = (ns == currentNS defs) || (visibility def /= Private) in
+            if visible
+              then do
+                ty <- prettyType (const ()) def.type
+                doc <- getDocsForName def.location def.fullname config
+                pure $ Just $
+                  MkEntry
+                    { category      = categorizeName (ns, un, n)
+                    , fullname      = def.fullname
+                    , type          = show ty
+                    , arguments     = arguments def.type
+                    , documentation = show doc
+                    }
+              else pure Nothing)
+    inImportedNamespaces 
+  let completionEntries = catMaybes visibleExportedNames
+  logD Completion "Found \{show (length completionEntries)} completion entries." 
+  pure $ foldl (\m , c => mergeWith (++) m (singleton c.category [c])) empty completionEntries
+  where
+    accessibleName : List Namespace -> Name -> Maybe (Namespace, UserName, Name)
+    accessibleName nps n = do
+      (ns, un) <- isUN n
+      if any (\p => isParentOf p ns || p == ns) nps
+        then Just (ns, un, n)
+        else Nothing
+
+mkCompletionItem : String -> Entry -> Maybe CompletionItem
+mkCompletionItem w (MkEntry c n ty ar doc) =
+  let shortName = show $ dropNS n in
+  let longName  = show n in
+  let item = MkCompletionItem
+        { label               = ""
+        , kind                = Nothing -- : Maybe CompletionItemKind
+        , tags                = Nothing -- : Maybe (List CompletionItemTag)
+        , detail              = Just ty
+        , documentation       = Just $ make doc
+        , deprecated          = Nothing -- : Maybe Bool
+        , preselect           = Nothing -- : Maybe Bool
+        , sortText            = Nothing -- : Maybe String
+        , filterText          = Nothing -- : Maybe String
+        , insertText          = Nothing -- : Maybe String
+        , insertTextFormat    = Nothing -- : Maybe InsertTextFormat
+        , insertTextMode      = Nothing -- : Maybe InsertTextMode
+        , textEdit            = Nothing -- : Maybe (OneOf [TextEdit, InsertReplaceEdit])
+        , additionalTextEdits = Nothing -- : Maybe (List TextEdit)
+        , commitCharacters    = Nothing -- : Maybe (List Char)
+        , command             = Nothing -- : Maybe Command
+        , data_               = Nothing -- : Maybe JSON
+        } in
+  let text = case ar of
+              [] => shortName
+              as => fastConcat
+                      [ "("
+                      , unwords
+                          $ shortName ::
+                            [ "?" ++ fromMaybe (shortName ++ "_arg_" ++ show i) x
+                            | (i,x) <- number as
+                            ]
+                      , ")"
+                      ]
+  in if (isInfixOf w shortName || isInfixOf w longName)
+    then Just $ case c of
+          CurrentNsName =>
+            { label      := shortName
+            , insertText := Just text
+            } item
+          InNestedNs =>
+            { label      := shortName
+            , insertText := Just text
+            } item
+          other =>
+            { label      := show n
+            , insertText := Just text
+            } item
+      else Nothing
+
+||| Gets the identifier at the position of cursor.
+|||
+||| If the document URI is not registered in the cache it returns Nothing.
+identifierAtCursor : Ref LSPConf LSPConfiguration
+                   => CompletionParams
+                   -> Core (Maybe String)
+identifierAtCursor params = do
+  Just content <- gets LSPConf (map snd . lookup params.textDocument.uri . virtualDocuments)
+    | Nothing => do
+        logD Completion "No virtual content is found for identifierAtCursor"
+        pure Nothing
+  let identifier = identifierAtPosition params.position content
+  logD Completion "Identifier at position \{show params.position} \{identifier}"
+  pure $ Just identifier
+
+||| Generating the completion response.
+|||
+||| The possible candidates are collected when saving the file, and the list could
+||| be enormous. Filtering it based on the identifier at the cursor position
+||| is necessary; otherwise, the generated JSON clogs up the channel and slows
+||| the response generation, making the developer experience terrible.
+export
+completion : Ref Ctxt Defs
+          => Ref MD Metadata
+          => Ref LSPConf LSPConfiguration
+          => CompletionParams
+          -> Core (Maybe CompletionList)
+completion params = do
+  logI Completion "Completion for \{show params.textDocument.uri}"
+  cache <- gets LSPConf completionCache
+  let Just completions = lookup params.textDocument.uri cache
+      | Nothing => do
+          logE Completion "No completions found for \{show params.textDocument.uri}"
+          pure Nothing
+  Just identifier <- identifierAtCursor params
+    | Nothing => do
+        pure Nothing
+  let nameCategories = if strLength identifier < 3
+        then [CurrentNsName, InNestedNs]
+        else [CurrentNsName, InNestedNs, OtherName, FieldName]
+  let candidates = concat $ mapMaybe (flip lookup completions) nameCategories
+  let suggestions@(_ :: _) = List.mapMaybe (mkCompletionItem identifier) candidates
+      | [] => do
+          logW Completion "No suggestion found for \{show params.textDocument.uri} \{show params.position}"
+          pure Nothing
+  logD Completion "Found \{show (length suggestions)} suggestions."
+  pure $ Just $ MkCompletionList
+    { isIncomplete = True
+    , items = suggestions
+    }

--- a/src/Language/LSP/Completion/Info.idr
+++ b/src/Language/LSP/Completion/Info.idr
@@ -1,0 +1,43 @@
+module Language.LSP.Completion.Info
+
+import Core.Name
+
+||| Category for Core.Name
+|||
+||| For short string suggestion, the suggestion list
+||| should be short, only names in current and nested
+||| namespaces should appear.
+public export
+data NameCategory
+  = CurrentNsName
+  | InNestedNs
+  | OtherName
+  | FieldName
+
+toNat : NameCategory -> Nat
+toNat CurrentNsName = 0
+toNat InNestedNs    = 1
+toNat OtherName     = 2
+toNat FieldName     = 3
+
+export
+Eq NameCategory where
+  a == b = toNat a == toNat b
+
+export
+Ord NameCategory where
+  compare a b = compare (toNat a) (toNat b)
+
+||| Completion entry
+|||
+||| This extract of information is used in generation of the
+||| completion response.
+public export
+record Entry where
+  constructor MkEntry
+  category      : NameCategory
+  fullname      : Name
+  type          : String
+  arguments     : List (Maybe String)
+  -- List of explicit arguments, when unnamed is Nothing, when user defined is Just str
+  documentation : String

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -4,19 +4,26 @@
 ||| (C) The Idris Community, 2021
 module Server.Configuration
 
-import Core.FC
-import Data.SortedSet
-import Data.SortedMap
-import Language.LSP.CodeAction
-import Language.LSP.Message.CodeAction
-import Language.LSP.Message.Initialize
-import Language.LSP.Message.Hover
-import Language.LSP.Message.Location
-import Language.LSP.Message.URI
-import Language.LSP.Message.SemanticTokens
 import public Libraries.Data.PosMap
+import public Libraries.Data.NameMap
+
+import Core.FC
+import Core.Name
+import Data.SortedMap
+import Data.SortedSet
+import Language.LSP.CodeAction
+import Language.LSP.Completion.Info
+import Language.LSP.Message.CodeAction
+import Language.LSP.Message.Hover
+import Language.LSP.Message.Initialize
+import Language.LSP.Message.Location
+import Language.LSP.Message.SemanticTokens
+import Language.LSP.Message.URI
 import Server.Severity
 import System.File
+import Data.String
+import Data.List1
+
 
 ||| Label for the configuration reference.
 public export
@@ -58,6 +65,10 @@ record LSPConfiguration where
   cachedHovers : PosMap (Range, Hover)
   ||| next id for requests to the server
   nextRequestId : Nat
+  ||| Caches for completions, created, updated when URIs are opened, extracted from Context.
+  completionCache : SortedMap DocumentURI (SortedMap Completion.Info.NameCategory (List Entry))
+  ||| Virtual file content caches
+  virtualDocuments : SortedMap DocumentURI (Int, String) -- Version content
 
 ||| Server default configuration. Uses standard input and standard output for input/output.
 export
@@ -79,4 +90,6 @@ defaultConfig =
     , cachedActions           = empty
     , cachedHovers            = empty
     , nextRequestId           = 0
+    , completionCache         = empty
+    , virtualDocuments        = empty
     }

--- a/src/Server/Log.idr
+++ b/src/Server/Log.idr
@@ -22,6 +22,7 @@ data Topic
   | CaseSplit
   | Channel
   | CodeAction
+  | Completion
   | Configuration
   | Diagnostic
   | DocumentHighlight
@@ -48,6 +49,7 @@ Show Topic where
   show CaseSplit = "Request.CodeAction.CaseSplit"
   show Channel = "Communication.Channel"
   show CodeAction = "CodeAction"
+  show Completion = "Request.Completion"
   show Configuration = "Request.Configuration"
   show Diagnostic = "Notification.Diagnostic"
   show DocumentHighlight = "Request.DocumentHighlight"

--- a/src/Server/VirtualDocument.idr
+++ b/src/Server/VirtualDocument.idr
@@ -1,0 +1,480 @@
+module Server.VirtualDocument
+
+-- The VirtualDocument is the version of the document that the LSP server maintains
+-- based on the incoming DidChange events. It should mirror the actively edited but
+-- unsaved content of the opened documents.
+
+import Data.Nat
+import Data.List
+import Data.String
+import Data.OneOf
+import Language.LSP.Message.Location
+import Language.LSP.Message.TextDocument
+import Decidable.Equality
+import Data.DPair
+import Control.Function
+import Syntax.PreorderReasoning
+import Data.Void
+
+%default total
+
+
+-- As the edits come in incremental change, the virtual document must be
+-- updated accordingly. The string needs to be split in a particular way,
+-- as detailed below:
+--
+-- Cut the string in half.
+--
+-- The `rangeSplit` cuts the string into three parts based on a Range.
+--
+-- In a Range based edit, the client sends a text that must replace the part
+-- within the Range found in the edit request. The Range consists of a start
+-- and an end position. Positions consist of a line and a character index.
+--
+-- Although the Position is encoded with line and char index, the file is
+-- represented as a String, in which a natural number indexes characters.
+-- The Position must be mapped to the string index-based encoding, which
+-- can be done via a string traversal. When a newline character is found,
+-- the line index is decreased. When the line index reaches zero, the character
+-- index is decreased. When the character index reaches zero, the string index of
+-- the Position is found. See below:
+--
+-- ...      m         n         p
+-- ...4567890123456789012345678901234567890....  (positions in string)
+--          ^              ^
+--        start           end                    (range in format (line:character))
+--
+-- As the text edit replaces a string in the Range, the prefix of the string
+-- must be kept. This means (0..start-1) both indexes included, then the new
+-- string must be inserted, and after the string from the end position must
+-- be included (end..length-1), both indexes included.
+--
+-- Although the situation is complex, the position encoding is based on line
+-- and character index, which must be decreased appropriately; the new line
+-- encoding of \r\n vs \n makes it trickier. However, this module only handles \n case.
+--
+-- Another complication is that the positions could refer to non-existing parts
+-- of the content. Such as, the Position could point after the end of
+-- the line end of the file.
+--
+-- The [before the first character of the line] range is encoded as the start position
+-- pointing after the line's last character and at the new line's first character
+-- such as (l,c+1) and (l+1,0).
+--
+-- Characters that point after the last character are considered invalid Range,
+-- and it must be interpreted as the last character of the line.
+
+
+Pos : Type
+Pos = (Nat, Nat)
+
+||| Line length as defined in LSP, newline character is not counted in.
+||| 
+||| See more:
+||| https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
+lineLength : String -> Nat
+lineLength ""  = 0
+lineLength str = assert_total $
+  let l = strLength str in
+  if isNL (strIndex str (l - 1))
+    then minus (cast l) 1
+    else cast l
+
+-- Take the string up to the position, character addressed by the position is included.
+takePos : Pos -> String -> String
+takePos (l,c) str =
+  let ls : List String = lines str in
+  let ln : Nat         = length ls in
+  case l < ln of
+    False => fastUnlines ls
+    True  =>
+      let (pre, post) = splitAt l ls in
+      case post of
+        [] => fastUnlines pre
+        (pl :: _) =>
+          let ll : Nat := lineLength pl in
+          let cx : Nat := if c > ll then ll else c in
+          fastUnlines $ pre ++ [strSubstr 0 (cast cx) pl]
+
+-- Drop the string up to the position, character addressed by the position is excluded.
+dropPos : Pos -> String -> String
+dropPos (l,c) str =
+  let ls : List String = lines str in
+  let ln : Nat         = length ls in
+  case l < ln of
+    False => "\n" -- Assumes always a newline at the end.
+    True =>
+      let (pre, post) = splitAt l ls in
+      case post of
+        [] => "\n"
+        (pl :: prest) =>
+          let ll : Nat := lineLength pl in
+          let cx : Nat := if c > ll then ll else c in
+          fastUnlines $ (strSubstr (cast cx) (cast (minus (cast (strLength pl)) cx)) pl :: prest)
+
+-- Newline character is always assumed from takePos and dropPos, and they must be
+-- removed to re-establish consistency. The SubString operations should be quick.
+dropLastNL : String -> String
+dropLastNL str = assert_total $ case strLength str of
+  0 => str
+  n => strSubstr 0 (n - 1) str
+
+-- Computes the pre and post part for the given range. Drops the part which is addressed by the range.
+rangeSplit : Pos -> Pos -> String -> (String, String)
+rangeSplit s e str = (dropLastNL $ takePos s str, dropLastNL $ dropPos e str)
+
+||| Updates the content string with the new string replacing the part between the start and end positions.
+|||
+||| This function is an approximation as the implementation is based on unlines and lines,
+||| and the lines function adds newline characters. The edge-case around newlines
+||| at the end of files is simplified to assume that the virtual content always
+||| has the empty line as the last line.
+update : Pos -> Pos -> String -> String -> String
+update s e new content =
+  let (pre, post) = rangeSplit s e content in
+  fastConcat [pre, new, post, "\n"]
+
+-- * Identifier
+
+-- Oversimplified version of the identifier.
+isIdentifierChar : Char -> Bool
+isIdentifierChar c = or [isAlphaNum c, c == '.', c == '_', c == '\'']
+
+-- * Word at position
+
+-- Determines the identifier at the index.
+--
+-- The implementation tart out scanning for the start position
+-- of the identifier and then looks for the end position.
+identifierAtIndex : String -> Nat -> String
+identifierAtIndex ""  i = ""
+identifierAtIndex str i = identifierPre (minus i 1) i
+  where
+    l : Nat
+    l = cast (strLength str)
+
+    identifierPost : Nat -> Nat -> String
+    identifierPost n Z = assert_total $ case isIdentifierChar (strIndex str (cast Z)) of
+      True => identifierPost n (S Z)
+      False => "" -- n < m -- assumed and this means an empty result
+    identifierPost n (S m) = assert_total $ case (S m) == l of
+      True  => strSubstr (cast n) (cast (minus (S m) n)) str
+      False => case isIdentifierChar (strIndex str (cast (S m))) of
+        True  => identifierPost n (S (S m))
+        False => strSubstr (cast n) (cast (minus (S m) n)) str
+
+    identifierPre : Nat -> Nat -> String
+    identifierPre Z m = assert_total $ case isIdentifierChar (strIndex str (cast Z)) of
+      True  => identifierPost Z m
+      False => identifierPost (S Z) m
+    identifierPre (S n) m = assert_total $ case isIdentifierChar (strIndex str (cast (S n))) of
+      True  => identifierPre n m
+      False => identifierPost (S (S n)) m
+
+-- Identifier at position.
+--
+-- Picks the line and char, if exists, otherwise reports empty string.
+identifierAtPos : Pos -> String -> String
+identifierAtPos (l,c) str =
+  let ls : List String := lines str in
+  let ln : Nat         := length ls in
+  case l > ln of
+    True  => ""
+    False => case drop l ls of
+      []        => ""
+      (line::_) =>
+        let ll : Nat := lineLength line in
+        let cx : Nat := if c > ll then ll else c in
+        identifierAtIndex line cx
+
+||| Determines an identifier like string at a given position.
+|||
+||| The empty String will be reported if the position points to a non-existent
+||| part of the String. This function is needed when generating the suggestion list.
+export
+identifierAtPosition : Position -> String -> String
+identifierAtPosition (MkPosition line character) str = identifierAtPos (cast line, cast character) str
+
+-- * LSP API
+
+validRange : (startline, startchar, endline, endchar : Nat) -> Bool
+validRange startline startchar endline endchar =
+  case compare startline endline of
+    LT => True
+    EQ => case compare startchar endchar of
+      LT => True
+      EQ => True
+      GT => False
+    GT => False
+
+changeRange : Range -> String -> String -> Either String String
+changeRange (MkRange (MkPosition sl sc) (MkPosition el ec)) content str =
+  case validRange (cast sl) (cast sc) (cast el) (cast ec) of
+    False => Left "Invalid range: \{show (sl,sc,el,ec)}"
+    True  => Right $ update (cast sl, cast sc) (cast el, cast ec) str content
+
+contentChangeEvent : TextDocumentContentChangeEvent -> String
+contentChangeEvent (MkTextDocumentContentChangeEvent text) = text
+
+contentChangeEventWithRange : TextDocumentContentChangeEventWithRange -> String -> Either String String
+contentChangeEventWithRange
+      (MkTextDocumentContentChangeEventWithRange range rangeLength text)
+      content
+  = changeRange range content text
+
+contentChangeOneOf : OneOf [TextDocumentContentChangeEvent, TextDocumentContentChangeEventWithRange] -> String -> Either String String
+contentChangeOneOf (Here c)         _ = Right $ contentChangeEvent c
+contentChangeOneOf (There (Here r)) c = contentChangeEventWithRange r c
+
+export
+changeVirtualContent
+  :  List (OneOf [TextDocumentContentChangeEvent, TextDocumentContentChangeEventWithRange])
+  -> String -> Either String String
+changeVirtualContent changes content = foldlM (flip contentChangeOneOf) content changes
+
+---------------------------
+-- Poor man's testing :) --
+---------------------------
+
+wordPosTestCase : Pos -> String -> String -> IO ()
+wordPosTestCase p str expected = do
+  let res = identifierAtPos p str
+  if expected == res
+    then do
+      putStrLn "OK: identifierAtPos \{show p} \{show str} \{show expected}"
+    else do
+      putStrLn "Failed: identifierAtPos \{show p} \{show str} \{show expected}"
+      putStrLn "Expected: \{show expected}"
+      putStrLn "Got: \{show res}"
+
+updateTestCase : Pos -> Pos -> String -> String -> String -> IO ()
+updateTestCase s e new str expected = do
+  let res = update s e new str
+  if expected == res
+    then do
+      putStrLn "OK: update \{show s} \{show e} \{show new} \{show str}"
+    else do
+      putStrLn "Failed: update \{show s} \{show e} \{show new} \{show str}"
+      putStrLn "Expected: \{show expected}"
+      putStrLn "Got: \{show res}"
+
+tests : IO ()
+tests = do
+
+  -- Update tests
+
+  do -- Empty string
+    let str = ""
+    updateTestCase (0,0) (0,0) ""     str "\n"
+    updateTestCase (0,0) (0,0) "a\nb" str "a\nb\n"
+    updateTestCase (0,0) (0,1) "a"    str "a\n"
+    updateTestCase (1,0) (1,0) "a"    str "a\n"
+    updateTestCase (1,1) (1,1) "a"    str "a\n"
+    updateTestCase (1,1) (1,2) "a"    str "a\n"
+    updateTestCase (1,1) (2,2) "a"    str "a\n"
+
+  do -- New line sting
+    let str = " "
+    updateTestCase (0,0) (0,0) ""     str " \n"
+    updateTestCase (0,0) (0,0) "a\nb" str "a\nb \n"
+    updateTestCase (0,0) (0,1) "a"    str "a\n"
+    updateTestCase (1,0) (1,0) "a"    str " a\n"
+    updateTestCase (1,1) (1,1) "a"    str " a\n"
+    updateTestCase (2,1) (2,1) ""     str " \n"
+    updateTestCase (2,1) (2,1) "a"    str " a\n"
+
+  do -- New line sting
+    let str = "\n"
+    updateTestCase (0,0) (0,0) ""     str "\n"
+    updateTestCase (0,0) (0,0) "a\nb" str "a\nb\n"
+    updateTestCase (0,0) (0,1) "a"    str "a\n"
+    updateTestCase (1,0) (1,0) "a"    str "a\n"
+    updateTestCase (1,1) (1,1) "a"    str "a\n"
+    updateTestCase (2,1) (2,1) ""     str "\n"
+    updateTestCase (2,1) (2,1) "a"    str "a\n"
+
+  do -- One line, no newline
+    --         0         1   1
+    --         012345678901234
+    let str = "This is a line."
+    updateTestCase (0,0) (0,0)   ""    str "This is a line.\n"
+    updateTestCase (0,5) (0,5)   ""    str "This is a line.\n"
+    updateTestCase (0,0) (0,0)   "a"   str "aThis is a line.\n"
+    updateTestCase (0,5) (0,5)   "a"   str "This ais a line.\n"
+    updateTestCase (0,5) (0,8)   "xx"  str "This xxa line.\n"
+    updateTestCase (0,5) (0,15)  "aaa" str "This aaa\n"
+    updateTestCase (0,3) (0,4)   ""    str "Thi is a line.\n"
+    updateTestCase (0,11) (0,20) ""    str "This is a l\n"
+
+  do -- One line, newline
+    --         0         1       1
+    --         0123456789012345678
+    let str = "This is a newline.\n"
+    updateTestCase (0,0) (0,0)  ""    str str
+    updateTestCase (0,5) (0,5)  ""    str str
+    updateTestCase (0,0) (0,0)  "a"   str "aThis is a newline.\n"
+    updateTestCase (0,5) (0,5)  "a"   str "This ais a newline.\n"
+    updateTestCase (0,5) (0,8)  "aa"  str "This aaa newline.\n"
+    updateTestCase (0,5) (0,18) "aaa" str "This aaa\n"
+    updateTestCase (0,18) (0,18) "a"  str "This is a newline.a\n"
+    updateTestCase (0,11) (0,20) ""   str "This is a n\n"
+
+  do -- Multiple lines, no newline at the last line.
+          --   0         1         2  2 0         1         2   2 0         1         2 2
+          --   012345678901234567890123 0123456789012345678901234 01234567890123456789012
+    let str = "This is the first line.\nThis is the second line.\nThis is the third line."
+    updateTestCase (1,0) (1,0)   ""   str (str ++ "\n")
+    updateTestCase (1,0) (1,0)   "a"  str "This is the first line.\naThis is the second line.\nThis is the third line.\n"
+    -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
+    -- If you want to specify a range that contains a line including the line ending character(s)
+    -- then use an end position denoting the start of the next line.
+    updateTestCase (1,24) (2,0)  "a"  str "This is the first line.\nThis is the second line.aThis is the third line.\n"
+    updateTestCase (1,19) (2,0)  "a"  str "This is the first line.\nThis is the second aThis is the third line.\n"
+    updateTestCase (1,0)  (2,0)  ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,0)  (2,0)  "a"  str "This is the first line.\naThis is the third line.\n"
+    updateTestCase (1,8)  (2,8)  ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,8)  (2,8)  "a " str "This is the first line.\nThis is a the third line.\n"
+    updateTestCase (1,8)  (2,9)  "x"  str "This is the first line.\nThis is xhe third line.\n"
+    updateTestCase (1,23) (2,22) ""   str "This is the first line.\nThis is the second line.\n"
+    updateTestCase (1,23) (2,22) "a"  str "This is the first line.\nThis is the second linea.\n"
+    updateTestCase (1,23) (2,23) "a"  str "This is the first line.\nThis is the second linea\n"
+    updateTestCase (0,23) (1,24) ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,0)  (1,40) ""   str "This is the first line.\n\nThis is the third line.\n"
+    updateTestCase (1,0)  (1,24) ""   str "This is the first line.\n\nThis is the third line.\n"
+    updateTestCase (1,10) (1,40) ""   str "This is the first line.\nThis is th\nThis is the third line.\n"
+    updateTestCase (1,0)  (4,40) ""   str "This is the first line.\n\n"
+    updateTestCase (1,10) (4,40) ""   str "This is the first line.\nThis is th\n"
+
+  do -- Multiple lines, newline at the last line.
+          --   0         1         2    0         1         2   2 0         1         2  2
+          --   012345678901234567890123 0123456789012345678901234 012345678901234567890123
+    let str = "This is the first line.\nThis is the second line.\nThis is the third line.\n"
+    updateTestCase (1,0) (1,0)   ""   str str
+    updateTestCase (1,0) (1,0)   "a"  str "This is the first line.\naThis is the second line.\nThis is the third line.\n"
+    -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range
+    -- If you want to specify a range that contains a line including the line ending character(s)
+    -- then use an end position denoting the start of the next line.
+    updateTestCase (1,24) (2,0)  "a"  str "This is the first line.\nThis is the second line.aThis is the third line.\n"
+    updateTestCase (1,19) (2,0)  "a"  str "This is the first line.\nThis is the second aThis is the third line.\n"
+    updateTestCase (1,0)  (2,0)  ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,0)  (2,0)  "a"  str "This is the first line.\naThis is the third line.\n"
+    updateTestCase (1,8)  (2,8)  ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,8)  (2,8)  "a " str "This is the first line.\nThis is a the third line.\n"
+    updateTestCase (1,8)  (2,9)  "x"  str "This is the first line.\nThis is xhe third line.\n"
+    updateTestCase (1,23) (2,22) ""   str "This is the first line.\nThis is the second line.\n"
+    updateTestCase (1,23) (2,22) "a"  str "This is the first line.\nThis is the second linea.\n"
+    updateTestCase (1,23) (2,23) "a"  str "This is the first line.\nThis is the second linea\n"
+    updateTestCase (0,23) (1,24) ""   str "This is the first line.\nThis is the third line.\n"
+    updateTestCase (1,0)  (1,40) ""   str "This is the first line.\n\nThis is the third line.\n"
+    updateTestCase (1,0)  (1,24) ""   str "This is the first line.\n\nThis is the third line.\n"
+    updateTestCase (1,10) (1,40) ""   str "This is the first line.\nThis is th\nThis is the third line.\n"
+    updateTestCase (1,0)  (4,40) ""   str "This is the first line.\n\n"
+    updateTestCase (1,10) (4,40) ""   str "This is the first line.\nThis is th\n"
+
+  -- Word at position tests.
+
+  do -- Empty string
+    wordPosTestCase (0,0)  "" ""
+    wordPosTestCase (0,10) "" ""
+    wordPosTestCase (1,0)  "" ""
+    wordPosTestCase (1,10) "" ""
+  
+  do -- New line
+    wordPosTestCase (0,0)  "\n" ""
+    wordPosTestCase (0,10) "\n" ""
+    wordPosTestCase (1,0)  "\n" ""
+    wordPosTestCase (1,10) "\n" ""
+    wordPosTestCase (2,0)  "\n" ""
+    wordPosTestCase (2,10) "\n" ""
+
+  do -- Space character
+    wordPosTestCase (0,0)  " " ""
+    wordPosTestCase (0,10) " " ""
+    wordPosTestCase (1,0)  " " ""
+    wordPosTestCase (1,10) " " ""
+  
+  do -- One line without newline
+    --         0         1   1
+    --         012345678901234
+    let str = "This is a line."
+    wordPosTestCase (0,0)  str "This"
+    wordPosTestCase (0,2)  str "This"
+    wordPosTestCase (0,4)  str "This"
+    wordPosTestCase (0,5)  str "is"
+    wordPosTestCase (0,6)  str "is"
+    wordPosTestCase (0,7)  str "is"
+    wordPosTestCase (0,8)  str "a"
+    wordPosTestCase (0,9)  str "a"
+    wordPosTestCase (0,10) str "line."
+    wordPosTestCase (0,12) str "line."
+    wordPosTestCase (0,14) str "line."
+    wordPosTestCase (0,20) str "line."
+    wordPosTestCase (1,0)  str ""
+
+  do -- One line with newline
+    --         0         1    1
+    --         0123456789012345
+    let str = "This is a line.\n"
+    wordPosTestCase (0,0)  str "This"
+    wordPosTestCase (0,2)  str "This"
+    wordPosTestCase (0,4)  str "This"
+    wordPosTestCase (0,5)  str "is"
+    wordPosTestCase (0,6)  str "is"
+    wordPosTestCase (0,7)  str "is"
+    wordPosTestCase (0,8)  str "a"
+    wordPosTestCase (0,9)  str "a"
+    wordPosTestCase (0,10) str "line."
+    wordPosTestCase (0,12) str "line."
+    wordPosTestCase (0,14) str "line."
+    wordPosTestCase (0,20) str "line."
+    wordPosTestCase (1,0)  str ""
+
+  do -- Three lines without newline
+          --   0         1         2    0         1         2   2 0         1         2 2
+          --   012345678901234567890123 0123456789012345678901234 01234567890123456789012
+    let str = "This is the first line.\nThis is the second line.\nThis is the third line."
+    wordPosTestCase (0,0)  str "This"
+    wordPosTestCase (0,2)  str "This"
+    wordPosTestCase (0,4)  str "This"
+    wordPosTestCase (0,5)  str "is"
+    wordPosTestCase (0,6)  str "is"
+    wordPosTestCase (0,7)  str "is"
+    wordPosTestCase (0,8)  str "the"
+    wordPosTestCase (0,12) str "first"
+    wordPosTestCase (0,21) str "line."
+    wordPosTestCase (0,30) str "line."
+    wordPosTestCase (1,0)  str "This"
+    wordPosTestCase (1,14) str "second"
+    wordPosTestCase (1,21) str "line."
+    wordPosTestCase (1,30) str "line."
+    wordPosTestCase (2,0)  str "This"
+    wordPosTestCase (2,14) str "third"
+    wordPosTestCase (2,21) str "line."
+    wordPosTestCase (2,30) str "line."
+    wordPosTestCase (3,0)  str ""
+    wordPosTestCase (3,30) str ""
+
+  do -- Three lines with newline
+          --   0         1         2    0         1         2   2 0         1         2  2
+          --   012345678901234567890123 0123456789012345678901234 012345678901234567890123
+    let str = "This is the first line.\nThis is the second line.\nThis is the third line.\n"
+    wordPosTestCase (0,0)  str "This"
+    wordPosTestCase (0,2)  str "This"
+    wordPosTestCase (0,4)  str "This"
+    wordPosTestCase (0,5)  str "is"
+    wordPosTestCase (0,6)  str "is"
+    wordPosTestCase (0,7)  str "is"
+    wordPosTestCase (0,8)  str "the"
+    wordPosTestCase (0,12) str "first"
+    wordPosTestCase (0,21) str "line."
+    wordPosTestCase (0,30) str "line."
+    wordPosTestCase (1,0)  str "This"
+    wordPosTestCase (1,14) str "second"
+    wordPosTestCase (1,21) str "line."
+    wordPosTestCase (1,30) str "line."
+    wordPosTestCase (2,0)  str "This"
+    wordPosTestCase (2,14) str "third"
+    wordPosTestCase (2,21) str "line."
+    wordPosTestCase (2,30) str "line."
+    wordPosTestCase (3,0)  str ""
+    wordPosTestCase (3,30) str ""


### PR DESCRIPTION
Resolves #139 

The Completion list resolution is purely syntactical. It is based on the identifier around the cursor. 

The main problem I had to solve was maintaining the document's unsaved version, which I call as VirtualDocument. I tested this version implementing the CallHiearchy, and it felt smooth on my low-end machine. My original approach involved more dependent types and linear scans of strings, but that obscured the readability. Hence, I settled down with the simple lines/unlines approach, which introduces a bit of inconsistency around newlines and needs fixing. 

The suggestions are syntactical based on the cursor's position and around the identifier. The implementation doesn't distinguish between expression and non-expression context and renders completion everywhere in the file, even in comments and import lines. The main reason for this is that every DidChange notification invalidates some part of the LSP context, and there is no way to know what Idris thinks about the position of that cursor. Having the location information would be a bigger refactor I wanted to avoid introducing in this change, as the completion already feels useful. 

The recipe for such a refactor is the following;

- For every `DidChange`, the LSP could maintain a `Pos -> Maybe Pos` transformation, which maps the virtual document position to the position of the original document
- The LSP shouldn't invalidate the context at every change. Information from the `Context` environment and `Metadata` could be reused to determine what the completion needs to know about the typing context.

Possible improvements and low-hanging fruits for future work:

- The content of the VirtualDocument could be stored in an IORef rather than in the configuration state. It would make the config state lighter when updating its content.
- The completion list generation is purely syntactical; it generates suggestions everywhere (including import lines and comments), not in just expression context.
- When the user types `.`, only the field accessors should be rendered in the list.
- Suggest more in further tickets... :)