### PR TITLE
Add option to complete with only the function name

### DIFF
--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -69,6 +69,8 @@ record LSPConfiguration where
   completionCache : SortedMap DocumentURI (SortedMap Completion.Info.NameCategory (List Entry))
   ||| Virtual file content caches
   virtualDocuments : SortedMap DocumentURI (Int, String) -- Version content
+  ||| Insert only function name for completions
+  briefCompletions : Bool
 
 ||| Server default configuration. Uses standard input and standard output for input/output.
 export
@@ -92,4 +94,5 @@ defaultConfig =
     , nextRequestId           = 0
     , completionCache         = empty
     , virtualDocuments        = empty
+    , briefCompletions       = False
     }

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -178,6 +178,9 @@ processSettings (JObject xs) = do
          whenJust (parseSeverity ll) $ \l => update LSPConf ({ logSeverity := l})
        Just _ => logE Configuration "Incorrect type for log severity, expected string"
        Nothing => pure ()
+  case lookup "briefCompletions" xs of
+      Just (JBoolean b) => update LSPConf ({ briefCompletions := b})
+      _ => pure ()
 processSettings _ = logE Configuration "Incorrect type for options"
 
 isDirty : Ref LSPConf LSPConfiguration => DocumentURI -> Core Bool


### PR DESCRIPTION
Per discord, some users would like idris2-lsp completions to only include the function name so they don't have to delete or replace the argument placeholders when they're not wanted.  This PR adds a `briefCompletions` option to only use the function name in the completions.  I've defaulted to the current behavior.

It will require a change on the idris2-lsp-vscode side to select non-default behavior.  I will file a separate PR there.
