### PR TITLE
Fix build with latest idris

### DIFF
--- a/src/Server/QuickFix.idr
+++ b/src/Server/QuickFix.idr
@@ -88,7 +88,7 @@ findQuickfix caps uri err@(PatternVariableUnifies fc fct env n tm) =
     update LSPConf ({ quickfixes $= (codeAction ::) })
 findQuickfix caps uri err@(ValidCase fc _ (Left tm)) =
   whenJust (isNonEmptyFC fc) $ \fc => do
-    Just (f, args) <- (uncons' <=< init' <=< map words) <$> (getSourceLine (startLine fc + 1))
+    Just (f, args) <- (Utils.uncons' <=< init' <=< map words) <$> (getSourceLine (startLine fc + 1))
       | Nothing => logE QuickFix "Error while fetching source line" >> pure ()
     let line = unwords $ f :: args ++ ["=", "?\{f}_rhs_not_impossible"]
     diagnostic <- errorToDiagnostic caps uri err


### PR DESCRIPTION
This PR fixes the build with the latest Idris (ebbae42c8 and later) in a way that is still compatible with older versions of Idris.

In ebbae42c8, Idris gains `Data.List.uncons'` which clashes with `Server.Utils.uncons'` in a way that confuses the elaborator. I fixed this by qualifying the call to `uncons'`.  If we only want to work with ebbae42c8 and newer, a cleaner solution might be to remove `Server.Utils.uncons'`.

