### PR TITLE
Add global package directory to search paths (and update Idris2 submodule)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660510326,
+        "lastModified": 1660592437,
         "narHash": "sha256-xFumnivtVwu5fFBOrTxrv6fv3geHKF04RGP23EsDVaI=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "ef03f7ef74ec97fd91a016a51c9c9667fb315652",
+        "rev": "e7eac49074b70814b542fee987af2987dd0520b5",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705899926,
-        "narHash": "sha256-rZuuyDjnOPwnTbH3Uf174ORkcl1ghllV0Cq1tGCmxUE=",
+        "lastModified": 1710014003,
+        "narHash": "sha256-+JG+u1ex2ZLCMITYS0eEkCntF79yC79oXW56S3rAK4E=",
         "owner": "idris-lang",
         "repo": "Idris2",
-        "rev": "cf4c87cc71d044141d144be5e9d1b9eedbb95135",
+        "rev": "c3239cb4c0a6a001a59660111b5e3000db710d2b",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705899308,
-        "narHash": "sha256-hw6r6E3thdgoYH3UzboLfuUYJFg31hIXCe3jH01inzA=",
+        "lastModified": 1710013650,
+        "narHash": "sha256-vqHKH5XTNgZFzV9yssvoFbFeO9buqKnPHMRm8kK8POA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5836514c534568510e7c2f3ad358f70af0925088",
+        "rev": "8a16f9a618b9aff6c2992f559500f62363635700",
         "type": "github"
       },
       "original": {

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -175,7 +175,7 @@ startServer =
                    Nothing => pure ()
               pdirs <- coreLift $ idrisGetEnv "IDRIS2_PACKAGE_PATH"
               the (Core ()) $ case pdirs of
-                   Just path => do traverseList1_ addPackageDir (map trim (split (==pathSeparator) path))
+                   Just path => do traverseList1_ addPackageSearchPath (map trim (split (==pathSeparator) path))
                    Nothing => pure ()
               cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
               the (Core ()) $ case cg of

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -5,6 +5,7 @@ module Server.Main
 
 import Core.Context
 import Core.Core
+import Core.Directory
 import Core.InitPrimitives
 import Core.Metadata
 import Core.UnifyState
@@ -182,6 +183,7 @@ startServer =
                                   Just cg => setCG cg
                                   Nothing => throw (InternalError ("Unknown code generator " ++ show e))
                    Nothing => pure ()
+              addPackageSearchPath !pkgGlobalDirectory
               addPkgDir "prelude" anyBounds
               addPkgDir "base" anyBounds
               addDataDir (prefix_dir (dirs (options defs)) </> ("idris2-" ++ showVersion False Idris.Version.version) </> "support")


### PR DESCRIPTION
This Pull Request will be necessitated by https://github.com/idris-lang/Idris2/pull/3214 but it will also fail to build until that PR has merged.

In short, the global package search path has been moved out of a function called by both the compiler and the LSP and into the compiler's `updateEnv` function which the LSP largely reproduces in its `Main` module. The change in this PR mirrors the one made to `updateEnv` in the compiler. You can see the analogous change in the upstream PR here: https://github.com/idris-lang/Idris2/pull/3214/files#diff-2459d1bfe7d1e6e584656adf0a5d01e88b5de037ce1785d9a1ff432a04b43f80R79-R84.