### PR TITLE
fix: nix default derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 (import (fetchTarball
   "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
-  src = builtins.fetchGit ./.;
+  src = ./.;
 })
 .defaultNix


### PR DESCRIPTION
this fixes uses of the LSP nix non-flake derivation via IFD in downstream third party derivations.

the error being fixed is of the form:
```
warning: could not update cached head 'master' for 'file:///Users/matt/staging/idris/nix-idris2-packages/source'
error:
       … while evaluating the attribute 'defaultNix'
         at /nix/store/8kpx53qi52yhjai1vdw8zpa95iqa61bv-source/default.nix:229:5:
          228|   rec {
          229|     defaultNix =
             |     ^
          230|       (builtins.removeAttrs result ["__functor"])

       … in the left operand of the update (//) operator
         at /nix/store/8kpx53qi52yhjai1vdw8zpa95iqa61bv-source/default.nix:231:7:
          230|       (builtins.removeAttrs result ["__functor"])
          231|       // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})
             |       ^
          232|       // (if result ? packages.${system}.default then { default = result.packages.${system}.default; } else {});

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: opening file '/Users/matt/.cache/nix/gitv3/0z3lrsbh1py3jbzx1fj5csjzy86a6naw1dci6385nyjn0gij6s1b/refs/heads/master': No such file or directory
```