### PR TITLE
[ new ] Add a `GenerateDefNext` code action

### DIFF
--- a/src/Language/LSP/CodeAction.idr
+++ b/src/Language/LSP/CodeAction.idr
@@ -5,6 +5,7 @@ data IdrisAction
   = CaseSplit
   | ExprSearch
   | GenerateDef
+  | GenerateDefNext
   | MakeCase
   | MakeClause
   | MakeLemma
@@ -14,25 +15,27 @@ data IdrisAction
 
 export
 Eq IdrisAction where
-  CaseSplit   == CaseSplit   = True
-  ExprSearch  == ExprSearch  = True
-  GenerateDef == GenerateDef = True
-  MakeCase    == MakeCase    = True
-  MakeClause  == MakeClause  = True
-  MakeLemma   == MakeLemma   = True
-  MakeWith    == MakeWith    = True
-  RefineHole  == RefineHole  = True
-  Intro       == Intro       = True
+  CaseSplit       == CaseSplit   = True
+  ExprSearch      == ExprSearch  = True
+  GenerateDef     == GenerateDef = True
+  GenerateDefNext == GenerateDefNext = True
+  MakeCase        == MakeCase    = True
+  MakeClause      == MakeClause  = True
+  MakeLemma       == MakeLemma   = True
+  MakeWith        == MakeWith    = True
+  RefineHole      == RefineHole  = True
+  Intro           == Intro       = True
   _ == _ = False
 
 export
 Show IdrisAction where
-  show CaseSplit   = "CaseSplit"
-  show ExprSearch  = "ExprSearch"
-  show GenerateDef = "GenerateDef"
-  show MakeCase    = "MakeCase"
-  show MakeClause  = "MakeClause"
-  show MakeLemma   = "MakeLemma"
-  show MakeWith    = "MakeWith"
-  show RefineHole  = "RefineHole"
-  show Intro       = "Intro"
+  show CaseSplit       = "CaseSplit"
+  show ExprSearch      = "ExprSearch"
+  show GenerateDef     = "GenerateDef"
+  show GenerateDefNext = "GenerateDefNext"
+  show MakeCase        = "MakeCase"
+  show MakeClause      = "MakeClause"
+  show MakeLemma       = "MakeLemma"
+  show MakeWith        = "MakeWith"
+  show RefineHole      = "RefineHole"
+  show Intro           = "Intro"

--- a/src/Language/LSP/CodeAction/GenerateDef.idr
+++ b/src/Language/LSP/CodeAction/GenerateDef.idr
@@ -22,31 +22,6 @@ import TTImp.Interactive.GenerateDef
 import TTImp.TTImp
 import TTImp.TTImp.Functor
 
-printClause : Ref Ctxt Defs
-           => Ref Syn SyntaxInfo
-           => Maybe String -> Nat -> ImpClause -> Core String
-printClause l i (PatClause _ lhsraw rhsraw) = do
-  lhs <- pterm $ map defaultKindedName lhsraw
-  rhs <- pterm $ map defaultKindedName rhsraw
-  pure $ relit l "\{pack (replicate i ' ')}\{show lhs} = \{show rhs}"
-printClause l i (WithClause _ lhsraw rig wvraw prf flags csraw) = do
-  lhs <- pterm $ map defaultKindedName lhsraw
-  wval <- pterm $ map defaultKindedName wvraw
-  cs <- traverse (printClause l (i + 2)) csraw
-  pure (relit l ((pack (replicate i ' ')
-         ++ show lhs
-         ++ " with \{showCount rig}(" ++ show wval ++ ")"
-         ++ maybe "" (\ nm => " proof " ++ show nm) prf
-         ++ "\n"))
-         ++ showSep "\n" cs)
-printClause l i (ImpossibleClause _ lhsraw) = do
-  do lhs <- pterm $ map defaultKindedName lhsraw
-     pure $ relit l "\{pack (replicate i ' ')}\{show lhs} impossible"
-
-number : Nat -> List a -> List (Nat, a)
-number n [] = []
-number n (x :: xs) = (n, x) :: number (S n) xs
-
 generateDefKind : CodeActionKind
 generateDefKind = Other "refactor.rewrite.GenerateDef"
 

--- a/src/Language/LSP/CodeAction/GenerateDefNext.idr
+++ b/src/Language/LSP/CodeAction/GenerateDefNext.idr
@@ -24,31 +24,6 @@ import TTImp.Interactive.ExprSearch
 import TTImp.TTImp
 import TTImp.TTImp.Functor
 
-printClause : Ref Ctxt Defs
-           => Ref Syn SyntaxInfo
-           => Maybe String -> Nat -> ImpClause -> Core String
-printClause l i (PatClause _ lhsraw rhsraw) = do
-  lhs <- pterm $ map defaultKindedName lhsraw
-  rhs <- pterm $ map defaultKindedName rhsraw
-  pure $ relit l "\{pack (replicate i ' ')}\{show lhs} = \{show rhs}"
-printClause l i (WithClause _ lhsraw rig wvraw prf flags csraw) = do
-  lhs <- pterm $ map defaultKindedName lhsraw
-  wval <- pterm $ map defaultKindedName wvraw
-  cs <- traverse (printClause l (i + 2)) csraw
-  pure (relit l ((pack (replicate i ' ')
-         ++ show lhs
-         ++ " with \{showCount rig}(" ++ show wval ++ ")"
-         ++ maybe "" (\ nm => " proof " ++ show nm) prf
-         ++ "\n"))
-         ++ showSep "\n" cs)
-printClause l i (ImpossibleClause _ lhsraw) = do
-  do lhs <- pterm $ map defaultKindedName lhsraw
-     pure $ relit l "\{pack (replicate i ' ')}\{show lhs} impossible"
-
-number : Nat -> List a -> List (Nat, a)
-number n [] = []
-number n (x :: xs) = (n, x) :: number (S n) xs
-
 generateDefNextKind : CodeActionKind
 generateDefNextKind = Other "refactor.rewrite.GenerateDefNext"
 
@@ -73,6 +48,13 @@ buildCodeAction uri edit =
     , data_       = Nothing
     }
 
+-- first blank line going forward (in contrast to reversed implementation found in
+-- some other code actions.
+findBlankLine : List String -> Int -> Int
+findBlankLine [] acc = acc
+findBlankLine (x :: xs) acc = if trim x == "" then acc else findBlankLine xs (acc + 1)
+
+-- reproduced from compiler repo because it is not exported there (as of now)
 nextGenDef : {auto c : Ref Ctxt Defs} ->
              {auto u : Ref UST UState} ->
              {auto o : Ref ROpts REPLOpts} ->
@@ -117,41 +99,51 @@ generateDefNext params = do
                            Just (l, _) => l /= line
       when staleDefs $ do
         fuel <- gets LSPConf searchLimit
-        results <- lookupDefExact n defs.gamma
-        case results of
+        existingDef <- lookupDefExact n defs.gamma
+        case existingDef of
           Just None => do
-             catch (do searchdefs <- makeDefN (\p, n => onLine line p) fuel n -- makeDefSort (\p, n => onLine line p) fuel mostUsed n
-                       logD GenerateDefNext "got \{show $ length searchdefs} results"
-                       let sd' : Search (FC, List ImpClause) = foldr (\n,acc => n :: pure acc) Nil searchdefs
-                       update ROpts { gdResult := Just (line, pure sd') }
---                        Just _ <- nextGenDef 0
---                          | Nothing => pure ()
---                        logD GenerateDefNext "skipped one result"
---                        Just _ <- nextGenDef 0
---                          | Nothing => pure ()
---                        logD GenerateDefNext "got second result"
---                        Just _ <- nextGenDef 0
---                          | Nothing => pure ()
---                        logD GenerateDefNext "got third result"
+             catch (do searchdefs <- makeDefSort (\p, n => onLine line p) fuel mostUsed n
+                       update ROpts { gdResult := Just (line, pure searchdefs) }
                        pure ())
                    (\case Timeout _ => logI GenerateDefNext "Timed out" >> pure ()
                           err => logC GenerateDefNext "Unexpected error while searching" >> throw err)
           Just _ => logD GenerateDefNext "There is already a definition for \{show n}" >> pure ()
           Nothing => logD GenerateDefNext "Couldn't find type declaration at line \{show line}" >> pure ()
 
-      Just (line, (fc, cs)) <- nextGenDef 0
+      Just (line', (fc, cs)) <- nextGenDef 0
         | Nothing => logD GenerateDefNext "No more results" >> pure []
       let l : Nat = integerToNat $ cast $ startCol (toNonEmptyFC fc)
-      Just srcLine <- getSourceLine line
+      Just srcLine <- getSourceLine line'
         | Nothing => logE GenerateDefNext "Source line \{show line} not found" >> pure []
       let (markM, srcLineUnlit) = isLitLine srcLine
       lines <- traverse (printClause markM l) cs
 
       put Ctxt defs
 
-      let docURI = params.textDocument.uri
       let newLine = endLine loc + 1
-      let rng = MkRange (MkPosition newLine 0) (MkPosition newLine 0) -- insert
+
+      -- Not having an easy time figuring out how to determine how many
+      -- following lines should be replaced if there's a definition there
+      -- already (cycling defs and not on first one). probably just use
+      -- whitespace.
+      defToOverride <- lookupDefExact n defs.gamma
+      rng <- case defToOverride of
+           Nothing => do
+             logD GenerateDefNext "No def to override, inserting new def" 
+             pure $ MkRange (MkPosition newLine 0) (MkPosition newLine 0) -- insert
+           (Just None) => do
+             logD GenerateDefNext "No def to override, inserting new def" 
+             pure $ MkRange (MkPosition newLine 0) (MkPosition newLine 0) -- insert
+           (Just (PMDef pminfo args treeCT treeRT pats)) => do
+             src <- String.lines <$> getSource
+             let srcFromDef = drop (integerToNat (cast line)) src
+             let blank = findBlankLine srcFromDef line
+             pure $ MkRange (MkPosition newLine 0) (MkPosition blank 0) -- replace
+           (Just _) => do
+             logE GenerateDefNext "UNEXPECTED"
+             pure $ MkRange (MkPosition newLine 0) (MkPosition newLine 0) -- insert
+
+      let docURI = params.textDocument.uri
 
       action <- do
         let edit = MkTextEdit rng (String.unlines lines)

--- a/src/Language/LSP/CodeAction/GenerateDefNext.idr
+++ b/src/Language/LSP/CodeAction/GenerateDefNext.idr
@@ -1,0 +1,160 @@
+module Language.LSP.CodeAction.GenerateDefNext
+
+import Core.Context
+import Core.Core
+import Core.Env
+import Core.Metadata
+import Core.UnifyState
+import Data.String
+import Idris.REPL.Opts
+import Idris.Resugar
+import Idris.Syntax
+import Language.JSON
+import Language.LSP.CodeAction
+import Language.LSP.CodeAction.Utils
+import Language.LSP.Message
+import Language.LSP.Utils
+import Parser.Unlit
+import Server.Configuration
+import Server.Log
+import Server.Utils
+import Libraries.Data.Tap
+import TTImp.Interactive.GenerateDef
+import TTImp.Interactive.ExprSearch
+import TTImp.TTImp
+import TTImp.TTImp.Functor
+
+printClause : Ref Ctxt Defs
+           => Ref Syn SyntaxInfo
+           => Maybe String -> Nat -> ImpClause -> Core String
+printClause l i (PatClause _ lhsraw rhsraw) = do
+  lhs <- pterm $ map defaultKindedName lhsraw
+  rhs <- pterm $ map defaultKindedName rhsraw
+  pure $ relit l "\{pack (replicate i ' ')}\{show lhs} = \{show rhs}"
+printClause l i (WithClause _ lhsraw rig wvraw prf flags csraw) = do
+  lhs <- pterm $ map defaultKindedName lhsraw
+  wval <- pterm $ map defaultKindedName wvraw
+  cs <- traverse (printClause l (i + 2)) csraw
+  pure (relit l ((pack (replicate i ' ')
+         ++ show lhs
+         ++ " with \{showCount rig}(" ++ show wval ++ ")"
+         ++ maybe "" (\ nm => " proof " ++ show nm) prf
+         ++ "\n"))
+         ++ showSep "\n" cs)
+printClause l i (ImpossibleClause _ lhsraw) = do
+  do lhs <- pterm $ map defaultKindedName lhsraw
+     pure $ relit l "\{pack (replicate i ' ')}\{show lhs} impossible"
+
+number : Nat -> List a -> List (Nat, a)
+number n [] = []
+number n (x :: xs) = (n, x) :: number (S n) xs
+
+generateDefNextKind : CodeActionKind
+generateDefNextKind = Other "refactor.rewrite.GenerateDefNext"
+
+isAllowed : CodeActionParams -> Bool
+isAllowed params =
+  maybe True (\filter => (generateDefNextKind `elem` filter) || (RefactorRewrite `elem` filter)) params.context.only
+
+buildCodeAction : URI -> TextEdit -> CodeAction
+buildCodeAction uri edit =
+  MkCodeAction
+    { title       = "Generate next definition"
+    , kind        = Just RefactorRewrite
+    , diagnostics = Nothing
+    , isPreferred = Nothing
+    , disabled    = Nothing
+    , edit        = Just $ MkWorkspaceEdit
+        { changes           = Just (singleton uri [edit])
+        , documentChanges   = Nothing
+        , changeAnnotations = Nothing
+        }
+    , command     = Nothing
+    , data_       = Nothing
+    }
+
+nextGenDef : {auto c : Ref Ctxt Defs} ->
+             {auto u : Ref UST UState} ->
+             {auto o : Ref ROpts REPLOpts} ->
+             (reject : Nat) ->
+             Core (Maybe (Int, (FC, List ImpClause)))
+nextGenDef reject
+    = do opts <- get ROpts
+         let Just (line, res) = gdResult opts
+              | Nothing => pure Nothing
+         Just (res, next) <- nextResult res
+              | Nothing =>
+                    do put ROpts ({ gdResult := Nothing } opts)
+                       pure Nothing
+         put ROpts ({ gdResult := Just (line, next) } opts)
+         case reject of
+              Z => pure (Just (line, res))
+              S k => nextGenDef k
+
+export
+generateDefNext : Ref LSPConf LSPConfiguration
+               => Ref MD Metadata
+               => Ref Ctxt Defs
+               => Ref UST UState
+               => Ref Syn SyntaxInfo
+               => Ref ROpts REPLOpts
+               => CodeActionParams -> Core (List CodeAction)
+generateDefNext params = do
+  let True = isAllowed params
+    | False => logI GenerateDefNext "Skipped" >> pure []
+  logI GenerateDefNext "Checking for \{show params.textDocument.uri} at \{show params.range}"
+
+  withSingleLine GenerateDefNext params (pure []) $ \line => do
+    withMultipleCache GenerateDefNext params GenerateDefNext $ do
+      defs <- branch
+      Just (loc, n, _, _) <- findTyDeclAt (\p, n => onLine line p)
+        | Nothing => logD GenerateDef "No name found at line \{show line}" >> pure []
+      logD CaseSplit "Found type declaration \{show n}"
+
+      previousResults <- gdResult <$> get ROpts
+      let staleDefs = case previousResults of
+                           Nothing => True
+                           Just (l, _) => l /= line
+      when staleDefs $ do
+        fuel <- gets LSPConf searchLimit
+        results <- lookupDefExact n defs.gamma
+        case results of
+          Just None => do
+             catch (do searchdefs <- makeDefN (\p, n => onLine line p) fuel n -- makeDefSort (\p, n => onLine line p) fuel mostUsed n
+                       logD GenerateDefNext "got \{show $ length searchdefs} results"
+                       let sd' : Search (FC, List ImpClause) = foldr (\n,acc => n :: pure acc) Nil searchdefs
+                       update ROpts { gdResult := Just (line, pure sd') }
+--                        Just _ <- nextGenDef 0
+--                          | Nothing => pure ()
+--                        logD GenerateDefNext "skipped one result"
+--                        Just _ <- nextGenDef 0
+--                          | Nothing => pure ()
+--                        logD GenerateDefNext "got second result"
+--                        Just _ <- nextGenDef 0
+--                          | Nothing => pure ()
+--                        logD GenerateDefNext "got third result"
+                       pure ())
+                   (\case Timeout _ => logI GenerateDefNext "Timed out" >> pure ()
+                          err => logC GenerateDefNext "Unexpected error while searching" >> throw err)
+          Just _ => logD GenerateDefNext "There is already a definition for \{show n}" >> pure ()
+          Nothing => logD GenerateDefNext "Couldn't find type declaration at line \{show line}" >> pure ()
+
+      Just (line, (fc, cs)) <- nextGenDef 0
+        | Nothing => logD GenerateDefNext "No more results" >> pure []
+      let l : Nat = integerToNat $ cast $ startCol (toNonEmptyFC fc)
+      Just srcLine <- getSourceLine line
+        | Nothing => logE GenerateDefNext "Source line \{show line} not found" >> pure []
+      let (markM, srcLineUnlit) = isLitLine srcLine
+      lines <- traverse (printClause markM l) cs
+
+      put Ctxt defs
+
+      let docURI = params.textDocument.uri
+      let newLine = endLine loc + 1
+      let rng = MkRange (MkPosition newLine 0) (MkPosition newLine 0) -- insert
+
+      action <- do
+        let edit = MkTextEdit rng (String.unlines lines)
+        pure $ buildCodeAction docURI edit
+      -- TODO: retrieve the line length efficiently
+      pure [(MkRange (MkPosition line 0) (MkPosition line 1000), [action])]

--- a/src/Language/LSP/CodeAction/Utils.idr
+++ b/src/Language/LSP/CodeAction/Utils.idr
@@ -1,13 +1,19 @@
 module Language.LSP.CodeAction.Utils
 
-import Core.Core
+import Core.Context
 import Core.Context.Context
+import Core.Core
+import Idris.Resugar
+import Idris.Syntax
 import Language.LSP.CodeAction
 import Language.LSP.Message.CodeAction
 import Language.LSP.Message.Location
+import Parser.Unlit
 import Server.Configuration
 import Server.Log
 import Server.Utils
+import TTImp.TTImp
+import TTImp.TTImp.Functor
 
 ||| Check for code actions that require the request to be on a single line.
 ||| @topic Logging topic of the code action
@@ -70,3 +76,33 @@ withMultipleCache topic params action new =
                 pure $ concat $ snd <$> locs
        acts => do logD topic "Found cached action"
                   pure acts
+
+||| Pretty print a clause as source-code to be sent to the editor.
+||| Reproduced from compiler repo where this function is not exported.
+export
+printClause : Ref Ctxt Defs
+           => Ref Syn SyntaxInfo
+           => Maybe String -> Nat -> ImpClause -> Core String
+printClause l i (PatClause _ lhsraw rhsraw) = do
+  lhs <- pterm $ map defaultKindedName lhsraw
+  rhs <- pterm $ map defaultKindedName rhsraw
+  pure $ relit l "\{pack (replicate i ' ')}\{show lhs} = \{show rhs}"
+printClause l i (WithClause _ lhsraw rig wvraw prf flags csraw) = do
+  lhs <- pterm $ map defaultKindedName lhsraw
+  wval <- pterm $ map defaultKindedName wvraw
+  cs <- traverse (printClause l (i + 2)) csraw
+  pure (relit l ((pack (replicate i ' ')
+         ++ show lhs
+         ++ " with \{showCount rig}(" ++ show wval ++ ")"
+         ++ maybe "" (\ nm => " proof " ++ show nm) prf
+         ++ "\n"))
+         ++ showSep "\n" cs)
+printClause l i (ImpossibleClause _ lhsraw) = do
+  do lhs <- pterm $ map defaultKindedName lhsraw
+     pure $ relit l "\{pack (replicate i ' ')}\{show lhs} impossible"
+
+||| Zip some lines up with their indices starting at the given number.
+export
+number : Nat -> List a -> List (Nat, a)
+number n [] = []
+number n (x :: xs) = (n, x) :: number (S n) xs

--- a/src/Server/Log.idr
+++ b/src/Server/Log.idr
@@ -29,6 +29,7 @@ data Topic
   | DocumentSymbol
   | ExprSearch
   | GenerateDef
+  | GenerateDefNext
   | GotoDefinition
   | Hover
   | Intro
@@ -56,6 +57,7 @@ Show Topic where
   show DocumentSymbol = "Request.DocumentSymbol"
   show ExprSearch = "Request.CodeAction.ExprSearch"
   show GenerateDef = "Request.CodeAction.GenerateDef"
+  show GenerateDefNext = "Request.CodeAction.GenerateDefNext"
   show GotoDefinition = "Request.GotoDefinition"
   show Hover = "Request.Hover"
   show Intro = "Request.CodeAction.Intro"

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -250,7 +250,6 @@ loadURI conf uri version = do
     put MD (initMetadata (PhysicalIdrSrc modIdent))
     ignore $ ProcessIdr.process msgPrefix buildMsg fname modIdent
 
---   resetProofState
   let caps = (publishDiagnostics <=< textDocument) . capabilities $ conf
   update LSPConf ({ quickfixes := [], cachedActions := empty, cachedHovers := empty })
   traverse_ (findQuickfix caps uri) errs

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -35,6 +35,7 @@ import Language.LSP.CodeAction.AddClause
 import Language.LSP.CodeAction.CaseSplit
 import Language.LSP.CodeAction.ExprSearch
 import Language.LSP.CodeAction.GenerateDef
+import Language.LSP.CodeAction.GenerateDefNext
 import Language.LSP.CodeAction.Intro
 import Language.LSP.CodeAction.MakeCase
 import Language.LSP.CodeAction.MakeLemma
@@ -249,7 +250,7 @@ loadURI conf uri version = do
     put MD (initMetadata (PhysicalIdrSrc modIdent))
     ignore $ ProcessIdr.process msgPrefix buildMsg fname modIdent
 
-  resetProofState
+--   resetProofState
   let caps = (publishDiagnostics <=< textDocument) . capabilities $ conf
   update LSPConf ({ quickfixes := [], cachedActions := empty, cachedHovers := empty })
   traverse_ (findQuickfix caps uri) errs
@@ -440,9 +441,10 @@ handleRequest TextDocumentCodeAction params = whenActiveRequest $ \conf => do
         makeCaseAction <- makeCase params
         introActions <- map Just <$> intro params
         generateDefActions <- map Just <$> generateDef params
+        generateDefNextActions <- map Just <$> generateDefNext params
         let resp = flatten $ quickfixActions
                                ++ [splitAction, lemmaAction, withAction, clauseAction, makeCaseAction]
-                               ++ introActions ++ generateDefActions ++ exprSearchActions
+                               ++ introActions ++ generateDefActions ++ generateDefNextActions ++ exprSearchActions
         pure $ pure $ make resp)
     where
       flatten : List (Maybe CodeAction) -> List (OneOf [Command, CodeAction])


### PR DESCRIPTION
The existing LSP `GenerateDef` code action will generate a list of possible definitions for a type declaration. An alternative mode of interacting with these generated definitions would be to cycle through them.

This PR introduces the `GenerateDefNext` code action which cycles through generated defs inline (a previous def is replaced when the next one is requested).

In order for this new functionality to work, we need to carry forward proof search state across file loading. As best I can figure, this should be fine and has no negative impact on other existing LSP functionality, but there is definitely a possibility of regression in this area so we should be cognizant of the potential need to undo this change. If needed, the state needed for this `GenerateDefNext` code action could also be stored in LSP specific state instead of repl state.