### PR TITLE
[WIP] Support multi-ipkg setup; Rework how we build the workspace project and when we compute metadata (TTM)

### DIFF
--- a/pack.toml
+++ b/pack.toml
@@ -1,0 +1,5 @@
+[custom.all.idris2-lsp]
+type = "local"
+path = "."
+ipkg = "idris2-lsp.ipkg"
+packagePath = true

--- a/src/Language/LSP/Completion/Handler.idr
+++ b/src/Language/LSP/Completion/Handler.idr
@@ -82,6 +82,7 @@ arguments (PrimVal fc c)                               = []
 arguments (Erased fc why)                              = []
 arguments (TType fc n)                                 = []
 
+-- PERF: This is currently *very* slow. It can take up 5-10 seconds for when running this on this (idris2-lsp) project
 export
 covering
 completionNames : Ref Ctxt Defs

--- a/src/Language/LSP/Definition.idr
+++ b/src/Language/LSP/Definition.idr
@@ -65,13 +65,6 @@ gotoDefinition : Ref Ctxt Defs
               => DefinitionParams -> Core (Maybe Location)
 gotoDefinition params = do
   logI GotoDefinition "Checking for \{show params.textDocument.uri} at \{show params.position}"
-  -- Check actual doc
-  Just (actualUri, _) <- gets LSPConf openFile
-    | Nothing => logE GotoDefinition "No open file" >> pure Nothing
-  let True = actualUri == params.textDocument.uri
-      | False => do
-          logD GotoDefinition "Expected request for the currently opened file \{show actualUri}, instead received \{show params.textDocument.uri}"
-          pure Nothing
 
   let line = params.position.line
   let col  = params.position.character

--- a/src/Language/LSP/DocumentHighlight.idr
+++ b/src/Language/LSP/DocumentHighlight.idr
@@ -25,13 +25,8 @@ documentHighlights : Ref Ctxt Defs
                   => Ref LSPConf LSPConfiguration
                   => DocumentHighlightParams -> Core (List DocumentHighlight)
 documentHighlights params = do
-  logI DocumentHighlight "Searching for \{show params.textDocument.uri}"
-  Just (uri, _) <- gets LSPConf openFile
-    | Nothing => logE DocumentHighlight "No open file" >> pure []
-  let True = uri == params.textDocument.uri
-    | False => do
-        logD DocumentHighlight "Expected request for the currently opened file \{show uri}, instead received \{show params.textDocument.uri}"
-        pure []
+  let uri = show params.textDocument.uri
+  logI DocumentHighlight "Searching for \{uri}"
 
   let line = params.position.line
   let col  = params.position.character

--- a/src/Language/LSP/DocumentSymbol.idr
+++ b/src/Language/LSP/DocumentSymbol.idr
@@ -60,13 +60,9 @@ documentSymbol : Ref Ctxt Defs
               => Ref LSPConf LSPConfiguration
               => DocumentSymbolParams -> Core (List SymbolInformation)
 documentSymbol params = do
-  logI DocumentSymbol "Making for \{show params.textDocument.uri}"
-  Just (uri, _) <- gets LSPConf openFile
-    | Nothing => logE DocumentSymbol "No open file" >> pure []
-  let True = uri == params.textDocument.uri
-    | False => do
-        logD DocumentSymbol "Expected request for the currently opened file \{show uri}, instead received \{show params.textDocument.uri}"
-        pure []
+  let uri = params.textDocument.uri
+  logI DocumentSymbol "Making for \{show uri}"
+
   defs <- get Ctxt
   -- Get the current and visible namespaces from the context
   let currentNamespaces = defs.currentNS :: defs.nestedNS

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -71,8 +71,8 @@ record LSPConfiguration where
   virtualDocuments : SortedMap DocumentURI (Int, String) -- Version content
   ||| Insert only function name for completions
   briefCompletions : Bool
-  ||| Maybe specified .ipkg file
-  ipkgFile : Maybe String
+  ||| Maybe specified path to the .ipkg file
+  ipkgPath : Maybe String
 
 ||| Server default configuration. Uses standard input and standard output for input/output.
 export
@@ -97,5 +97,5 @@ defaultConfig =
     , completionCache         = empty
     , virtualDocuments        = empty
     , briefCompletions        = False
-    , ipkgFile                = Nothing
+    , ipkgPath                = Nothing
     }

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -47,8 +47,6 @@ record LSPConfiguration where
   ||| True if the client has completed the shutdown protocol.
   ||| @see https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#shutdown
   isShutdown : Bool
-  ||| The currently loaded file, if any, and its version.
-  openFile : Maybe (DocumentURI, Int)
   ||| Files with modification not saved. Command will fail on these files.
   dirtyFiles : SortedSet DocumentURI
   ||| Files with errors
@@ -85,7 +83,6 @@ defaultConfig =
     , logSeverity             = Debug
     , initialized             = Nothing
     , isShutdown              = False
-    , openFile                = Nothing
     , dirtyFiles              = empty
     , errorFiles              = empty
     , semanticTokensSentFiles = empty

--- a/src/Server/Configuration.idr
+++ b/src/Server/Configuration.idr
@@ -71,6 +71,8 @@ record LSPConfiguration where
   virtualDocuments : SortedMap DocumentURI (Int, String) -- Version content
   ||| Insert only function name for completions
   briefCompletions : Bool
+  ||| Maybe specified .ipkg file
+  ipkgFile : Maybe String
 
 ||| Server default configuration. Uses standard input and standard output for input/output.
 export
@@ -94,5 +96,6 @@ defaultConfig =
     , nextRequestId           = 0
     , completionCache         = empty
     , virtualDocuments        = empty
-    , briefCompletions       = False
+    , briefCompletions        = False
+    , ipkgFile                = Nothing
     }

--- a/src/Server/Main.idr
+++ b/src/Server/Main.idr
@@ -71,12 +71,12 @@ parseHeaderPart h = do
     Nothing => pure $ Right Nothing
 
 handleMessage : Ref LSPConf LSPConfiguration
-             => Ref Ctxt Defs
-             => Ref UST UState
-             => Ref Syn SyntaxInfo
-             => Ref MD Metadata
-             => Ref ROpts REPLOpts
-             => Core ()
+            => Ref Ctxt Defs
+            => Ref UST UState
+            => Ref Syn SyntaxInfo
+            => Ref MD Metadata
+            => Ref ROpts REPLOpts
+            => Core ()
 handleMessage = do
   inputHandle <- gets LSPConf inputHandle
   Right (Just l) <- parseHeaderPart inputHandle
@@ -150,21 +150,13 @@ runServer : Ref LSPConf LSPConfiguration
          => Core ()
 runServer = handleMessage >> runServer
 
-processCommandLineArgs : Ref LSPConf LSPConfiguration => List String -> Core ()
-processCommandLineArgs [] = pure ()
-processCommandLineArgs [ipkgFile] = do
-  update LSPConf {ipkgFile := Just ipkgFile}
-  logI Server "Set .ipkg file to \{ipkgFile}"
-processCommandLineArgs _ = throw (InternalError "Unexpected number of arguments")
-
-startServer : List String -> IO ()
-startServer extraCommandLineArgs =
+startServer : IO ()
+startServer =
   coreRun (do l <- newRef LSPConf defaultConfig
               defs <- initDefs
               c <- newRef Ctxt defs
               s <- newRef Syn initSyntax
               addPrimitives
-              processCommandLineArgs extraCommandLineArgs
               bprefix <- coreLift $ idrisGetEnv "IDRIS2_PREFIX"
               the (Core ()) $ case bprefix of
                    Just p => setPrefix p
@@ -215,8 +207,9 @@ printVersion = do
 
 main : IO ()
 main = do
-  (_ :: args) <- getArgs
+  (_::args) <- getArgs
     | _ => putStrLn "Invalid command line"
   case args of
     ["--version"] => printVersion
-    args => startServer args
+    [] => startServer
+    _ => putStrLn "Invalid Arguments"

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -234,12 +234,12 @@ loadURI conf uri version = do
     | Left err => do let msg = "Cannot load .ipkg file: \{show err}"
                      logE Channel msg
                      pure $ Left msg
-  logI Server ".ipkg file set to: \{packageFilePath}"
+  logI Channel ".ipkg file configured to: \{packageFilePath}"
   Right packageFileSource <- coreLift $ File.ReadWrite.readFile packageFilePath
     | Left err => do let msg = "Cannot read .ipkg at \{packageFilePath} with CWD \{!getWorkingDir}"
                      logE Channel msg
                      pure $ Left msg
-  logI Server ".ipkg file read!"
+  logI Channel ".ipkg file read!"
   let Just (packageFileDir, packageFileName) = splitParent packageFilePath
       | _ => throw $ InternalError "Tried to split empty string"
   let True = isSuffixOf ".ipkg" packageFileName
@@ -260,7 +260,7 @@ loadURI conf uri version = do
                 errs <- check pkg []
                 clock1 <- coreLift (clockTime Monotonic)
                 let dif = timeDifference clock1 clock0
-                logI Server "Type-checking finished in \{show (toNano dif)}ns with \{show (length errs)} errors"
+                logI Channel "Type-checking finished in \{show (toNano dif)}ns with \{show (length errs)} errors"
                 pure errs
             )
             -- FIXME: the compiler always dumps the errors on stdout, requires

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -188,8 +188,12 @@ processSettings (JObject xs) = do
       Just (JBoolean b) => update LSPConf ({ briefCompletions := b})
       _ => pure ()
   case lookup "ipkgPath" xs of
-      Just (JString path) => update LSPConf ({ ipkgPath := Just path})
-      _ => update LSPConf ({ ipkgPath := Nothing})
+      Just (JString path) => do
+        logI Channel "Set .ipkg path to \{path}"
+        update LSPConf ({ ipkgPath := Just path})
+      _ => do
+        logI Channel "Unset .ipkg path"
+        update LSPConf ({ ipkgPath := Nothing})
 processSettings _ = logE Configuration "Incorrect type for options"
 
 isDirty : Ref LSPConf LSPConfiguration => DocumentURI -> Core Bool

--- a/src/Server/ProcessMessage.idr
+++ b/src/Server/ProcessMessage.idr
@@ -189,7 +189,7 @@ processSettings (JObject xs) = do
       _ => pure ()
   case lookup "ipkgPath" xs of
       Just (JString path) => update LSPConf ({ ipkgPath := Just path})
-      _ => pure ()
+      _ => update LSPConf ({ ipkgPath := Nothing})
 processSettings _ = logE Configuration "Incorrect type for options"
 
 isDirty : Ref LSPConf LSPConfiguration => DocumentURI -> Core Bool


### PR DESCRIPTION
TODO: Update the description

The main change is around `loadURI`. First we figure out which ipkg file to use (either one provided in LSP configuration by the client or we try to find one via idris2 api). The first option takes priority. Next we call an api function that builds the main module (including all dependencies) specified in the ipkg file. Rest is unchanged.

Another small change is addition of a new LSP configuration option, called "ipkgPath", which can be sent to the server from the client on initialisation and/or changed any time later. It represents optional relative path to the ipkg file. The root path is that where LSP server has been started.

Functionally, the PR makes it possible to switch/specify the ipkg file mid-air. Next time `loadURI` gets triggered the project will get rebuilt against the last specified ipkg file. Moreover, due to TTC cache, the switch may be close to instantaneous in case no single file needs a fresh build or a rebuild.