### PR TITLE
compatibility with idris PR 3480

### DIFF
--- a/src/Language/LSP/SignatureHelp.idr
+++ b/src/Language/LSP/SignatureHelp.idr
@@ -67,7 +67,7 @@ renderDataTypeInfo n d@(DCon tag arity newtypeArg) = do
 renderDataTypeInfo n d@(TCon tag arity parampos detpos flags mutwith datacons detagabbleBy) = do
   -- Render the data structure information for the type.
   context <- gets Ctxt gamma
-  constructors <- for datacons $ \dn => case !(lookupDefName dn context) of
+  constructors <- for (fromMaybe [] datacons) $ \dn => case !(lookupDefName dn context) of
     [(_, _, DCon _ _ _)] => do
       fullName <- getFullName dn
       pure $ Just " | \{show fullName} ..."


### PR DESCRIPTION
This commit fixes a build error that will occur after [idris-lang/Idris2#3840](https://github.com/idris-lang/Idris2/pull/3480) is merged.

After 3480 is merged, this will unblock idris2-pack. But we would need to update again to point the Idris2 submodule to the new commit to support users who build with the submodule.


