### PR TITLE
Add missing README on configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Server options that can be set via the `initializationOptions` object in the ini
 |`showImplicits`|`boolean`|Show implicits in hovers|
 |`showMachineNames`|`boolean`|Show machine names in hovers|
 |`fullNamespace`|`boolean`|Show full namespace in hovers|
+|`briefCompletions`|`boolean`|Insert only function name for completions|
 
 ## Code Actions Filters
 As per specification, client can filter requested code actions with the `context.only` field in the request parameters.


### PR DESCRIPTION
Add `briefCompletions` option introduced in https://github.com/idris-community/idris2-lsp/pull/197 to the README.